### PR TITLE
fix: use workspace file root for multi-root .code-workspace support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { TempFoldersProvider } from './provider';
 import { TempFoldersDragAndDropController } from './dragAndDrop';
 import { registerCommands } from './commands';
 import { I18n } from './i18n';
+import { getWorkspaceRootUri } from './util';
 import { TempFolderItem, TempFileItem } from './treeItems';
 
 /**
@@ -180,9 +181,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerCommands(context, provider, stableMcpPath);
 
     // Watch for .vscode/virtualTab.json changes
-    const rootUri = vscode.workspace.workspaceFile
-        ? vscode.Uri.joinPath(vscode.workspace.workspaceFile, '..')
-        : vscode.workspace.workspaceFolders?.[0]?.uri;
+    const rootUri = getWorkspaceRootUri();
     const configPath = rootUri
         ? new vscode.RelativePattern(rootUri, '.vscode/virtualTab.json')
         : null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,8 +180,11 @@ export async function activate(context: vscode.ExtensionContext) {
     registerCommands(context, provider, stableMcpPath);
 
     // Watch for .vscode/virtualTab.json changes
-    const configPath = vscode.workspace.workspaceFolders?.[0]
-        ? new vscode.RelativePattern(vscode.workspace.workspaceFolders[0], '.vscode/virtualTab.json')
+    const rootUri = vscode.workspace.workspaceFile
+        ? vscode.Uri.joinPath(vscode.workspace.workspaceFile, '..')
+        : vscode.workspace.workspaceFolders?.[0]?.uri;
+    const configPath = rootUri
+        ? new vscode.RelativePattern(rootUri, '.vscode/virtualTab.json')
         : null;
 
     if (configPath) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -326,8 +326,10 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
     }
 
     private getWorkspaceRootPath(): string | undefined {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        return workspaceFolder?.uri.fsPath;
+        if (vscode.workspace.workspaceFile) {
+            return vscode.Uri.joinPath(vscode.workspace.workspaceFile, '..').fsPath;
+        }
+        return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     }
 
     private initBuiltInGroup() {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,6 +8,7 @@ import { AutoGrouper } from './core/AutoGrouper';
 import { BookmarkManager } from './core/BookmarkManager';
 import { GroupManager, OptimisticLockError } from './core/GroupManager';
 import { PathUtils } from './core/PathUtils';
+import { getWorkspaceRootUri } from './util';
 
 /**
  * Type-safe helper to extract a URI from a VS Code Tab's input.
@@ -326,10 +327,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
     }
 
     private getWorkspaceRootPath(): string | undefined {
-        if (vscode.workspace.workspaceFile) {
-            return vscode.Uri.joinPath(vscode.workspace.workspaceFile, '..').fsPath;
-        }
-        return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        return getWorkspaceRootUri()?.fsPath;
     }
 
     private initBuiltInGroup() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,18 @@ import * as vscode from 'vscode';
 import { TempGroup } from './types';
 
 /**
+ * Returns the root URI of the current workspace.
+ * For multi-root workspaces, this is the directory containing the .code-workspace file.
+ * For single-folder workspaces, this is the first workspace folder's URI.
+ */
+export function getWorkspaceRootUri(): vscode.Uri | undefined {
+    if (vscode.workspace.workspaceFile) {
+        return vscode.Uri.joinPath(vscode.workspace.workspaceFile, '..');
+    }
+    return vscode.workspace.workspaceFolders?.[0]?.uri;
+}
+
+/**
  * Get all files from a group and all its nested child groups (recursive).
  * Uses a visited-Set to prevent infinite loops from circular parent references.
  * Returns a de-duplicated list of file URI strings.


### PR DESCRIPTION
## Summary

Fixes #26

When a `.code-workspace` file is used (multi-root workspace), the extension was using `workspaceFolders[0]` to locate `.vscode/virtualTab.json`. This is incorrect because in a multi-root workspace the root folders listed inside the `.code-workspace` file are the workspace members, not the directory containing the workspace file itself.

The correct root is the directory that contains the `.code-workspace` file, available via `vscode.workspace.workspaceFile`.

## Changes

- **`src/provider.ts` — `getWorkspaceRootPath()`**: When `workspace.workspaceFile` is set, derive the root path from its parent directory (`vscode.Uri.joinPath(workspaceFile, '..')`). Fall back to `workspaceFolders[0]` for single-folder workspaces (existing behaviour).

- **`src/extension.ts` — file watcher**: Apply the same logic when constructing the `RelativePattern` for watching `.vscode/virtualTab.json`, so the watcher targets the correct directory in multi-root workspaces.

## Test plan

- [ ] Open a single-folder workspace — `virtualTab.json` is still loaded from `.vscode/` in that folder (unchanged behaviour).
- [ ] Open a `.code-workspace` file with multiple root folders — `virtualTab.json` is now loaded from `.vscode/` next to the `.code-workspace` file, not from the first root folder.
- [ ] Edit `.vscode/virtualTab.json` next to the `.code-workspace` file and confirm the file watcher triggers a reload correctly.