### PR TITLE
docs: refresh release docs for v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
-## [0.5.4] - 2026-05-13
+## [0.5.5] - 2026-05-13
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.5.4] - 2026-05-13
+
+### Changed
+
+- Improved automated publishing for the VS Code Marketplace and Open VSX release flow.
+- Added validation and UI test workflows to keep multi-root workspace support safer to maintain.
+
 ## [0.5.0] - 2026-05-10
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     <meta property="og:url" content="https://winterdrive.github.io/vscode-virtual-tabs/">
     <meta property="og:title" content="VirtualTabs - Custom File Groups, AI Agent Integration & MCP for VS Code">
     <meta property="og:description"
-        content="Organize files into custom virtual groups with MCP Server for AI agent integration. Generate Agent Skills for Cursor, Copilot, Claude, Kiro, Antigravity. AI-ready context export & persistent workspace management.">
+        content="Organize files into custom virtual groups with MCP Server for AI agent integration. Generate Agent Skills for Cursor, Copilot, Claude, Kiro, Antigravity. AI-ready context export, multi-root workspace scopes, and persistent workspace management.">
     <meta property="og:image"
         content="https://winterdrive.github.io/vscode-virtual-tabs/assets/vscode-virtualtabs-grouping-banner1024X512.png">
     <meta property="og:image:width" content="1024">
@@ -45,7 +45,7 @@
     <meta property="twitter:url" content="https://winterdrive.github.io/vscode-virtual-tabs/">
     <meta property="twitter:title" content="VirtualTabs - Custom File Groups, AI Agent Integration & MCP for VS Code">
     <meta property="twitter:description"
-        content="Organize files into custom virtual groups with MCP Server for AI agent integration. Generate Agent Skills for Cursor, Copilot, Claude, Kiro, Antigravity. Persistent workspace management.">
+        content="Organize files into custom virtual groups with MCP Server for AI agent integration. Generate Agent Skills for Cursor, Copilot, Claude, Kiro, Antigravity. Multi-root scopes and persistent workspace management.">
     <meta property="twitter:image"
         content="https://winterdrive.github.io/vscode-virtual-tabs/assets/vscode-virtualtabs-grouping-banner1024X512.png">
     <meta property="twitter:image:alt" content="VirtualTabs VS Code Extension - File Grouping Interface">
@@ -76,9 +76,9 @@
         "url": "https://winterdrive.github.io/vscode-virtual-tabs/",
         "downloadUrl": "https://marketplace.visualstudio.com/items?itemName=winterdrive.virtual-tabs",
         "installUrl": "https://marketplace.visualstudio.com/items?itemName=winterdrive.virtual-tabs",
-        "softwareVersion": "0.4.9",
+        "softwareVersion": "0.5.4",
         "datePublished": "2024-01-01",
-        "dateModified": "2026-04-04",
+        "dateModified": "2026-05-13",
         "author": {
             "@type": "Person",
             "name": "winterdrive",
@@ -119,6 +119,7 @@
             "MCP Server for AI agent integration",
             "Agent Skill generation (Cursor, Copilot, Claude, Kiro, Antigravity)",
             "Custom file grouping across directories",
+            "Multi-root workspace scopes with per-project configs",
             "AI-ready context export",
             "Persistent workspace management",
             "Drag and drop file organization",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -83,6 +83,7 @@ In MVC/MVVM or large-scale projects, related files are often scattered across de
 - **AI Context Export** — One-click copy all files as LLM-ready context.
 - **Portable Config** — Settings saved to `.vscode/virtualTab.json` for team sharing.
 - **AI Agent Integration (MCP)** — Connect AI agents (Cursor, Claude, etc.) to manage groups programmatically.
+- **Multi-Root Workspace Scopes** — Keep groups separated per workspace folder in multi-root projects.
 - **Auto Reveal & Sync** — Automatically focus active files and sync with native editor groups.
 - **Send to...** — Quickly send selected files or groups to pre-configured destinations.
 - **File Reordering** — Custom manual ordering via Drag & Drop or keyboard shortcuts.
@@ -101,6 +102,7 @@ In MVC/MVVM or large-scale projects, related files are often scattered across de
 ### 📁 Group Management
 
 - **Create/Rename**: Right-click panel or groups to manage.
+- **Multi-root scopes**: In a multi-root workspace, each detected project appears as its own section. Use the scope header to add a group, open that scope's config, reveal its storage, or clear only that scope.
 - **Sub-Groups**: Right-click a group → **Add Sub-Group** (or drag one group into another).
 - **Auto-Sync**: The built-in "Open Editors" group automatically tracks your native tabs.
 - **Drag & Drop**:
@@ -153,7 +155,7 @@ VirtualTabs provides full AI agent integration via the **Model Context Protocol 
 1. **Group by Task, Not Folder**: Think about the feature you're working on.
 2. **Use Bookmarks for Logic Flow**: Mark key decision points in your code.
 3. **Curate AI Context**: Group only necessary files (5-10) to maximize LLM accuracy and reduce token noise.
-4. **Share with Team**: Commit `.vscode/virtualTab.json` to share curated project views.
+4. **Share with Team**: Commit each project's `.vscode/virtualTab.json` to share curated project views.
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,10 +1,10 @@
 # VirtualTabs
 > VirtualTabs is a VS Code extension with a bundled MCP Server for organizing files into persistent, cross-directory virtual groups and integrating with AI agents (Cursor, Copilot, Claude, Kiro, Antigravity).
 
-VirtualTabs helps developers manage complex workspaces by grouping related files regardless of location, and provides Agent Skill generation for AI-driven workflows. A built-in MCP Server exposes 15+ tools for programmatic group management, ensuring that logical context is preserved even after closing the editor.
+VirtualTabs helps developers manage complex workspaces by grouping related files regardless of location, including multi-root workspace projects with separate scope-level configs. It also provides Agent Skill generation for AI-driven workflows. A built-in MCP Server exposes 15+ tools for programmatic group management, ensuring that logical context is preserved even after closing the editor.
 
 ## Documentation
-- [README](https://raw.githubusercontent.com/winterdrive/VirtualTabs/main/readme.md): Core features, installation, and usage guide.
+- [README](https://raw.githubusercontent.com/winterdrive/VirtualTabs/main/README.md): Core features, installation, and usage guide.
 - [Development Guide](https://raw.githubusercontent.com/winterdrive/VirtualTabs/main/DEVELOPMENT.md): Setup, architecture, and contribution instructions.
 - [Changelog](https://raw.githubusercontent.com/winterdrive/VirtualTabs/main/CHANGELOG.md): History of releases and updates.
 - [Full Context Documentation](https://winterdrive.github.io/VirtualTabs/llms-full.txt): A single file containing the full text of all critical documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.5.4",
+            "version": "0.5.5",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [


### PR DESCRIPTION
## Summary

- Add a `0.5.4` changelog entry for release automation and validation workflows.
- Refresh LLM-facing docs with multi-root workspace scope support.
- Update the docs landing page metadata to version `0.5.4` and include multi-root workspace scopes in social/structured data.

## Notes

- README.md and README.zh-TW.md already covered the multi-root workspace scope behavior, so this PR only refreshes the derived docs and release metadata.
- No extension runtime code changed.

## Test plan

- `git diff --check`
- Searched docs for stale `0.4.9`, `2026-04-04`, and lowercase `readme.md` references.
