### PR TITLE
fix: inherit sourceScopeId in auto groups for multi-root workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.7.2] - Auto Group Scope Fix - 2026-06-02
+
+### 🐛 Bug Fix
+
+- **Auto group saved to wrong scope in multi-root workspace** ([#56](https://github.com/winterdrive/vscode-virtual-tabs/issues/56)): Auto groups created by "Auto Group by Extension" and "Auto Group by Modified Date" now correctly inherit the source group's `sourceScopeId`, so they are saved to the right project root's `.vscode/virtualTab.json`. Previously, missing `sourceScopeId` caused the save route to fall back to the first workspace root, making auto groups disappear on reload in multi-root workspaces.
+
+### 🧪 Tests
+
+- **Unit tests**: 13 tests verifying `sourceScopeId` inheritance for both extension and date auto groups, including edge cases (no scope, non-first scope, empty input).
+- **E2E tests**: 2 UI tests confirming auto groups land in the correct root's config file and leave the other root's config untouched.
+
 ## [0.7.1] - Demo Recording Pipeline - 2026-05-26
 
 ### 🎬 Product Demo Recording

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.7.1",
+            "version": "0.7.2",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1390,7 +1390,8 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
             name: `${I18n.getAutoGroupName(ext)} @ ${group.name}`, // Naming: .ext @ Source
             files,
             auto: true,
-            sourceGroupId: group.id
+            sourceGroupId: group.id,
+            sourceScopeId: group.sourceScopeId
         }));
 
         // Find fresh index of group because filtering might have shifted it
@@ -1458,8 +1459,8 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                     files,
                     auto: true,
                     autoGroupType: 'modifiedDate',
-                    sourceGroupId: group.id
-                    // Removed parentGroupId to make it sibling
+                    sourceGroupId: group.id,
+                    sourceScopeId: group.sourceScopeId
                 });
             }
         }

--- a/src/test/ui/multiRootScopes.ui.test.ts
+++ b/src/test/ui/multiRootScopes.ui.test.ts
@@ -9,6 +9,7 @@ import {
     ViewControl,
     VSBrowser
 } from 'vscode-extension-tester';
+import { By, Key } from 'selenium-webdriver';
 import { expect } from 'chai';
 
 const fixtureRoot = path.resolve(__dirname, '../../../test-resources/multi-root');
@@ -156,12 +157,73 @@ async function getVisibleTreeLabels(): Promise<string[]> {
     `) as string[];
 }
 
-function readConfig(configPath: string): Array<{ name?: string }> {
-    return JSON.parse(fs.readFileSync(configPath, 'utf8')) as Array<{ name?: string }>;
+function readConfig(configPath: string): Array<{ name?: string; auto?: boolean }> {
+    return JSON.parse(fs.readFileSync(configPath, 'utf8')) as Array<{ name?: string; auto?: boolean }>;
 }
 
 function writeConfig(configPath: string, groups: Array<{ id: string; name: string; files: string[] }>): void {
     fs.writeFileSync(configPath, `${JSON.stringify(groups, null, 2)}\n`);
+}
+
+async function dismissContextViews(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    const isMenuOpen = async (): Promise<boolean> => {
+        const menus = await driver.findElements(By.css('.context-view.monaco-menu-container'));
+        for (const menu of menus) {
+            try { if (await menu.isDisplayed()) return true; } catch { /* stale */ }
+        }
+        return false;
+    };
+    if (!(await isMenuOpen())) return;
+    await driver.actions().sendKeys(Key.ESCAPE).perform().catch(() => undefined);
+    await driver.sleep(150);
+    await driver.actions().sendKeys(Key.ESCAPE).perform().catch(() => undefined);
+    await driver.wait(async () => !(await isMenuOpen()), 2_000).catch(() => false);
+}
+
+async function rightClickAndSelectMenuItem(rowLabel: string, menuItemLabel: string): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    await dismissContextViews();
+
+    const row = await driver.wait(async () => {
+        const rows = await driver.findElements(By.css('.monaco-list-row'));
+        for (const r of rows) {
+            try {
+                const text = (await r.getText()).trim();
+                if (text.includes(rowLabel)) return r;
+            } catch { /* stale */ }
+        }
+        return null;
+    }, 10_000, `Tree row "${rowLabel}" not found`) as Awaited<ReturnType<typeof driver.findElement>>;
+
+    await driver.actions().click(row).perform();
+    await driver.sleep(300);
+    await driver.actions().contextClick(row).perform();
+
+    await driver.wait(async () => {
+        try {
+            const menu = await driver.findElement(By.css('.context-view.monaco-menu-container'));
+            return await menu.isDisplayed();
+        } catch { return false; }
+    }, 6_000, 'Context menu did not appear');
+
+    await driver.sleep(300);
+
+    const item = await driver.wait(async () => {
+        const items = await driver.findElements(
+            By.css('.context-view.monaco-menu-container .action-label')
+        );
+        for (const it of items) {
+            try {
+                const text = (await it.getText()).trim();
+                if (text === menuItemLabel) return it;
+            } catch { /* stale */ }
+        }
+        return null;
+    }, 5_000, `Context menu item "${menuItemLabel}" not found`) as Awaited<ReturnType<typeof driver.findElement>>;
+
+    await item.click();
+    await driver.sleep(500);
 }
 
 describe('Virtual Tabs - Multi-root scopes UI', function () {
@@ -221,5 +283,82 @@ describe('Virtual Tabs - Multi-root scopes UI', function () {
 
         expect(afterA).to.include(expectedName);
         expect(afterB).to.deep.equal(beforeB);
+    });
+
+    describe('auto group scope isolation (Issue #56)', function () {
+        const autoGroupSourceConfig = [
+            {
+                id: 'repo-b-auto-test',
+                name: 'Repo B Auto Test',
+                files: ['src/main.ts', 'config/app.json']
+            }
+        ];
+
+        before(async function () {
+            writeConfig(repoBConfigPath, autoGroupSourceConfig);
+            const sidebar = await openVirtualTabsView();
+            await clickToolbarButton(sidebar, /refresh/i);
+            await waitForTreeLabel('Repo B Auto Test');
+        });
+
+        after(async function () {
+            writeConfig(repoBConfigPath, repoBInitialConfig);
+            const sidebar = await openVirtualTabsView();
+            await clickToolbarButton(sidebar, /refresh/i);
+        });
+
+        it('auto group by extension on Repo-B group saves auto groups only to Repo-B config', async function () {
+            await rightClickAndSelectMenuItem('Repo B Auto Test', 'Auto Group by Extension');
+
+            // Auto groups should appear in the tree
+            await waitForTreeLabel('.ts @ Repo B Auto Test', 15_000);
+
+            // Wait for Repo-B config to be persisted
+            await VSBrowser.instance.driver.wait(() => {
+                const names = readConfig(repoBConfigPath).map(g => g.name);
+                return names.some(n => n && n.includes('.ts @ Repo B Auto Test'));
+            }, 10_000, 'Auto group .ts was not persisted to Repo-B config');
+
+            const repoBGroups = readConfig(repoBConfigPath);
+            const repoAGroups = readConfig(repoAConfigPath);
+
+            // Both extension buckets saved to Repo-B
+            expect(repoBGroups.some(g => g.name && g.name.includes('.ts @ Repo B Auto Test'))).to.be.true;
+            expect(repoBGroups.some(g => g.name && g.name.includes('.json @ Repo B Auto Test'))).to.be.true;
+
+            // Repo-A config must be untouched
+            expect(repoAGroups.some(g => g.name && g.name.includes('Auto Test'))).to.be.false;
+        });
+
+        it('auto group by modified date on Repo-B group saves auto groups only to Repo-B config', async function () {
+            // Reset Repo-B config before this test so previous auto groups don't interfere
+            writeConfig(repoBConfigPath, autoGroupSourceConfig);
+            const sidebar = await openVirtualTabsView();
+            await clickToolbarButton(sidebar, /refresh/i);
+            await waitForTreeLabel('Repo B Auto Test');
+
+            await rightClickAndSelectMenuItem('Repo B Auto Test', 'Auto Group by Modified Date');
+
+            // At least one date bucket should appear
+            await VSBrowser.instance.driver.wait(async () => {
+                const labels = await getVisibleTreeLabels();
+                return labels.some(l => l.includes('@ Repo B Auto Test'));
+            }, 15_000, 'No date auto group appeared under Repo B Auto Test');
+
+            // Wait for persistence
+            await VSBrowser.instance.driver.wait(() => {
+                const groups = readConfig(repoBConfigPath);
+                return groups.some(g => g.auto === true);
+            }, 10_000, 'Date auto groups were not persisted to Repo-B config');
+
+            const repoBGroups = readConfig(repoBConfigPath);
+            const repoAGroups = readConfig(repoAConfigPath);
+
+            // Date auto groups landed in Repo-B
+            expect(repoBGroups.some(g => g.auto === true)).to.be.true;
+
+            // Repo-A config must be untouched
+            expect(repoAGroups.some(g => g.auto === true)).to.be.false;
+        });
     });
 });

--- a/src/test/unit/autoGroupScopeId.test.ts
+++ b/src/test/unit/autoGroupScopeId.test.ts
@@ -1,0 +1,231 @@
+/**
+ * 單元測試：auto group 建立時繼承 sourceScopeId
+ *
+ * 修復 Issue #56：在 multi-root workspace 下，addAutoGroupsByExt()
+ * 與 autoGroupByModifiedDate() 建立的 auto group 必須繼承來源群組的
+ * sourceScopeId，否則存檔路由會 fallback 至第一個 scope，導致 auto
+ * group 存錯位置或 refresh 後消失。
+ *
+ * 此測試萃取 provider.ts 中兩個方法的核心建立邏輯，以純函式測試。
+ */
+
+// ─── 型別 ─────────────────────────────────────────────────────────────────────
+
+interface SourceGroup {
+    id: string;
+    name: string;
+    files: string[];
+    sourceScopeId?: string;
+}
+
+interface AutoGroup {
+    id: string;
+    name: string;
+    files: string[];
+    auto: true;
+    sourceGroupId: string;
+    sourceScopeId: string | undefined;
+    autoGroupType?: 'extension' | 'modifiedDate';
+}
+
+// ─── 鏡像 provider.ts 的建立邏輯 ─────────────────────────────────────────────
+
+/**
+ * 鏡像 provider.ts addAutoGroupsByExt() 的 auto group 建立邏輯。
+ * 依副檔名分桶，產生 auto group 陣列。
+ */
+function buildExtAutoGroups(source: SourceGroup): AutoGroup[] {
+    const extMap: Record<string, string[]> = {};
+    for (const uriStr of source.files) {
+        const parts = uriStr.split('.');
+        const ext = parts.length > 1 ? parts.pop()!.toLowerCase() : 'other';
+        if (!extMap[ext]) extMap[ext] = [];
+        extMap[ext].push(uriStr);
+    }
+
+    return Object.entries(extMap).map(([ext, files]) => ({
+        id: `auto_ext_${ext}`,
+        name: `.${ext} @ ${source.name}`,
+        files,
+        auto: true,
+        sourceGroupId: source.id,
+        sourceScopeId: source.sourceScopeId
+    }));
+}
+
+/**
+ * 鏡像 provider.ts autoGroupByModifiedDate() 的 auto group 建立邏輯。
+ * 依日期桶產生 auto group 陣列（桶內容由外部傳入，方便測試）。
+ */
+function buildDateAutoGroups(
+    source: SourceGroup,
+    dateAssignments: Map<string, string[]>
+): AutoGroup[] {
+    const dateOrder = ['today', 'yesterday', 'thisWeek', 'lastWeek', 'thisMonth', 'older'];
+    const result: AutoGroup[] = [];
+
+    for (const slot of dateOrder) {
+        const files = dateAssignments.get(slot);
+        if (files && files.length > 0) {
+            result.push({
+                id: `auto_date_${slot}`,
+                name: `[Auto] ${slot} @ ${source.name}`,
+                files,
+                auto: true,
+                autoGroupType: 'modifiedDate',
+                sourceGroupId: source.id,
+                sourceScopeId: source.sourceScopeId
+            });
+        }
+    }
+
+    return result;
+}
+
+// ─── 測試：按副檔名自動分組 ───────────────────────────────────────────────────
+
+describe('buildExtAutoGroups — sourceScopeId 繼承', () => {
+    const sourceWithScope: SourceGroup = {
+        id: 'grp-1',
+        name: 'Feature Files',
+        files: ['file:///repo-b/src/index.ts', 'file:///repo-b/src/util.ts', 'file:///repo-b/config/app.json'],
+        sourceScopeId: 'scope-repo-b'
+    };
+
+    test('每個 auto group 都繼承來源群組的 sourceScopeId', () => {
+        const groups = buildExtAutoGroups(sourceWithScope);
+        expect(groups.length).toBeGreaterThan(0);
+        for (const g of groups) {
+            expect(g.sourceScopeId).toBe('scope-repo-b');
+        }
+    });
+
+    test('.ts 桶與 .json 桶都帶有正確 sourceScopeId', () => {
+        const groups = buildExtAutoGroups(sourceWithScope);
+        const tsGroup = groups.find(g => g.name.startsWith('.ts'));
+        const jsonGroup = groups.find(g => g.name.startsWith('.json'));
+
+        expect(tsGroup).toBeDefined();
+        expect(jsonGroup).toBeDefined();
+        expect(tsGroup!.sourceScopeId).toBe('scope-repo-b');
+        expect(jsonGroup!.sourceScopeId).toBe('scope-repo-b');
+    });
+
+    test('sourceGroupId 指向來源群組 id', () => {
+        const groups = buildExtAutoGroups(sourceWithScope);
+        for (const g of groups) {
+            expect(g.sourceGroupId).toBe('grp-1');
+        }
+    });
+
+    test('來源群組無 sourceScopeId 時，auto group 的 sourceScopeId 為 undefined', () => {
+        const sourceWithoutScope: SourceGroup = {
+            id: 'grp-x',
+            name: 'No Scope',
+            files: ['file:///workspace/index.ts']
+        };
+        const groups = buildExtAutoGroups(sourceWithoutScope);
+        expect(groups[0].sourceScopeId).toBeUndefined();
+    });
+
+    test('非第一個 scope 的群組產生的 auto group 不會被誤存到第一個 scope', () => {
+        const scopeB: SourceGroup = {
+            id: 'grp-b',
+            name: 'Repo B Group',
+            files: ['file:///repo-b/main.ts'],
+            sourceScopeId: 'scope-b'
+        };
+        const scopeA: SourceGroup = {
+            id: 'grp-a',
+            name: 'Repo A Group',
+            files: ['file:///repo-a/main.ts'],
+            sourceScopeId: 'scope-a'
+        };
+
+        const bGroups = buildExtAutoGroups(scopeB);
+        const aGroups = buildExtAutoGroups(scopeA);
+
+        expect(bGroups[0].sourceScopeId).toBe('scope-b');
+        expect(aGroups[0].sourceScopeId).toBe('scope-a');
+        expect(bGroups[0].sourceScopeId).not.toBe(aGroups[0].sourceScopeId);
+    });
+
+    test('空 files 時回傳空陣列', () => {
+        const emptySource: SourceGroup = { id: 'g', name: 'Empty', files: [], sourceScopeId: 'scope-b' };
+        expect(buildExtAutoGroups(emptySource)).toHaveLength(0);
+    });
+});
+
+// ─── 測試：按修改日期自動分組 ─────────────────────────────────────────────────
+
+describe('buildDateAutoGroups — sourceScopeId 繼承', () => {
+    const sourceWithScope: SourceGroup = {
+        id: 'grp-2',
+        name: 'Mixed Dates',
+        files: ['file:///repo-b/new.ts', 'file:///repo-b/old.ts'],
+        sourceScopeId: 'scope-repo-b'
+    };
+
+    const dateMap = new Map<string, string[]>([
+        ['today', ['file:///repo-b/new.ts']],
+        ['older', ['file:///repo-b/old.ts']]
+    ]);
+
+    test('每個 date auto group 都繼承來源群組的 sourceScopeId', () => {
+        const groups = buildDateAutoGroups(sourceWithScope, dateMap);
+        expect(groups.length).toBeGreaterThan(0);
+        for (const g of groups) {
+            expect(g.sourceScopeId).toBe('scope-repo-b');
+        }
+    });
+
+    test('autoGroupType 為 modifiedDate', () => {
+        const groups = buildDateAutoGroups(sourceWithScope, dateMap);
+        for (const g of groups) {
+            expect(g.autoGroupType).toBe('modifiedDate');
+        }
+    });
+
+    test('sourceGroupId 指向來源群組 id', () => {
+        const groups = buildDateAutoGroups(sourceWithScope, dateMap);
+        for (const g of groups) {
+            expect(g.sourceGroupId).toBe('grp-2');
+        }
+    });
+
+    test('來源群組無 sourceScopeId 時，date auto group 的 sourceScopeId 為 undefined', () => {
+        const sourceWithoutScope: SourceGroup = {
+            id: 'grp-y',
+            name: 'No Scope',
+            files: ['file:///workspace/index.ts']
+        };
+        const groups = buildDateAutoGroups(sourceWithoutScope, new Map([['today', ['file:///workspace/index.ts']]]));
+        expect(groups[0].sourceScopeId).toBeUndefined();
+    });
+
+    test('日期桶依序輸出（today 先於 older）', () => {
+        const multiDateMap = new Map<string, string[]>([
+            ['older', ['file:///repo-b/old.ts']],
+            ['today', ['file:///repo-b/new.ts']]
+        ]);
+        const groups = buildDateAutoGroups(sourceWithScope, multiDateMap);
+        expect(groups[0].name).toContain('today');
+        expect(groups[1].name).toContain('older');
+    });
+
+    test('空 dateAssignments 時回傳空陣列', () => {
+        expect(buildDateAutoGroups(sourceWithScope, new Map())).toHaveLength(0);
+    });
+
+    test('只有空陣列值的桶不產生 auto group', () => {
+        const sparseMap = new Map<string, string[]>([
+            ['today', []],
+            ['older', ['file:///repo-b/old.ts']]
+        ]);
+        const groups = buildDateAutoGroups(sourceWithScope, sparseMap);
+        expect(groups).toHaveLength(1);
+        expect(groups[0].name).toContain('older');
+    });
+});
+
+export {};

--- a/test-resources/multi-root/Repo-B/config/app.json
+++ b/test-resources/multi-root/Repo-B/config/app.json
@@ -1,0 +1,3 @@
+{
+  "name": "repo-b-app"
+}

--- a/test-resources/multi-root/Repo-B/src/main.ts
+++ b/test-resources/multi-root/Repo-B/src/main.ts
@@ -1,0 +1,1 @@
+export const greeting = 'hello';


### PR DESCRIPTION
## Summary

- \`addAutoGroupsByExt()\` 和 \`autoGroupByModifiedDate()\` 建立 auto group 時，沒有繼承來源群組的 \`sourceScopeId\`
- 在 multi-root workspace 下，存檔路由因此 fallback 到第一個 scope，導致 auto group 存錯位置或 refresh 後消失
- 修復方式：建立 auto group 時加入 \`sourceScopeId: group.sourceScopeId\`

Fixes #56

## Test plan

- [ ] 在 multi-root workspace 開啟兩個以上的 project root
- [ ] 對**非第一個** root 底下的群組執行 Auto Group by Extension
- [ ] 執行 Auto Group by Modified Date
- [ ] 確認 auto group 出現在正確的 root scope 底下
- [ ] 關閉並重開 VS Code，確認 auto group 持久化到正確的 \`.vscode/virtualTab.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)