### PR TITLE
[codex] Fix VirtualTabs folder/group drag data transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ test-results/
 /coverage
 test-ui-output.txt
 docs/assets/fix_rounded_corners.py
+docs/_archive/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
-## [0.7.5] - Folder Drop DataTransfer Fix - 2026-06-21
+## [0.7.5] - Drag-and-Drop DataTransfer Fixes - 2026-06-21
 
 ### 🐛 Bug Fix
 
 - **Folder drops from VS Code Explorer** ([#60](https://github.com/winterdrive/vscode-virtual-tabs/issues/60)): External folder drops now handle VS Code's special `files` DataTransfer MIME entries in addition to `text/uri-list`, so folders dragged from Explorer or the OS can be expanded and added to a VirtualTabs group.
+- **Group drags to AI chat sidebars** ([#60](https://github.com/winterdrive/vscode-virtual-tabs/issues/60)): Dragging a VirtualTabs group now also provides `text/plain` file references, giving chat inputs such as GitHub Copilot a readable fallback when they do not consume `text/uri-list` from extension tree items.
 
 ### 🧪 Tests
 
-- Added unit coverage for URI-list parsing, external DataTransfer file URI extraction, and duplicate URI handling.
+- Added unit coverage for URI-list parsing, external DataTransfer file URI extraction, duplicate URI handling, and chat-friendly drag text formatting.
 
 ## [0.7.4] - Skill Installer UX - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.7.5] - Folder Drop DataTransfer Fix - 2026-06-21
+
+### 🐛 Bug Fix
+
+- **Folder drops from VS Code Explorer** ([#60](https://github.com/winterdrive/vscode-virtual-tabs/issues/60)): External folder drops now handle VS Code's special `files` DataTransfer MIME entries in addition to `text/uri-list`, so folders dragged from Explorer or the OS can be expanded and added to a VirtualTabs group.
+
+### 🧪 Tests
+
+- Added unit coverage for URI-list parsing, external DataTransfer file URI extraction, and duplicate URI handling.
+
 ## [0.7.4] - Skill Installer UX - 2026-06-16
 
 ### 🧠 Skill Installer UX (closes #25)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.7.4",
+    "version": "0.7.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.7.4",
+            "version": "0.7.5",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.7.4",
+    "version": "0.7.5",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [

--- a/src/core/DropUriParser.ts
+++ b/src/core/DropUriParser.ts
@@ -26,3 +26,14 @@ export function uniqueUriStrings(uris: readonly string[]): string[] {
     }
     return Array.from(unique);
 }
+
+export function formatDraggedFilesPlainText(paths: readonly string[]): string {
+    if (paths.length === 0) {
+        return '';
+    }
+
+    return [
+        'Use these files as context:',
+        ...paths.map(path => `#file:${path}`)
+    ].join('\n');
+}

--- a/src/core/DropUriParser.ts
+++ b/src/core/DropUriParser.ts
@@ -1,0 +1,28 @@
+export interface DataTransferFileLike {
+    readonly uri?: { toString(): string };
+}
+
+export function parseUriList(value: unknown): string[] {
+    if (typeof value !== 'string') {
+        return [];
+    }
+
+    return value
+        .split(/\r?\n/)
+        .map(value => value.trim())
+        .filter(value => value.length > 0 && !value.startsWith('#'));
+}
+
+export function extractDataTransferFileUris(files: readonly DataTransferFileLike[]): string[] {
+    return files
+        .map(file => file.uri?.toString())
+        .filter((uri): uri is string => typeof uri === 'string' && uri.length > 0);
+}
+
+export function uniqueUriStrings(uris: readonly string[]): string[] {
+    const unique = new Set<string>();
+    for (const uri of uris) {
+        unique.add(uri);
+    }
+    return Array.from(unique);
+}

--- a/src/dragAndDrop.ts
+++ b/src/dragAndDrop.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { TempFoldersProvider } from './provider';
-import { TempFolderItem, TempFileItem, ScopeHeaderItem } from './treeItems';
+import { TempFolderItem, TempFileItem, ScopeHeaderItem, EditorGroupItem } from './treeItems';
 import { I18n } from './i18n';
 import { extractDataTransferFileUris, formatDraggedFilesPlainText, parseUriList, uniqueUriStrings } from './core/DropUriParser';
 
@@ -31,6 +31,7 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
         // Handle multi-file drag from the tree view
         const fileItems = source.filter((item): item is TempFileItem => item instanceof TempFileItem);
         const groupItems = source.filter((item): item is TempFolderItem => item instanceof TempFolderItem);
+        const editorGroupItems = source.filter((item): item is EditorGroupItem => item instanceof EditorGroupItem);
 
         const uriSet = new Set<string>();
 
@@ -46,7 +47,9 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
         if (groupItems.length > 0) {
             for (const item of groupItems) {
                 const group = this.provider.groups[item.groupIdx];
-                if (!group || group.builtIn || !group.id) continue;
+                // Skip only groups without a valid id (builtIn groups are now allowed
+                // so that "Currently Open Files" can produce a drag payload).
+                if (!group || !group.id) continue;
                 const groupFiles = this.collectGroupFilesRecursive(group.id);
                 for (const uri of groupFiles) {
                     uriSet.add(uri);
@@ -55,6 +58,17 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
 
             // Store group items for internal drag-drop
             dataTransfer.set('application/vnd.code.tree.virtualTabsView', new vscode.DataTransferItem(groupItems));
+        }
+
+        // Handle EditorGroupItem (split-editor sub-nodes under the built-in group).
+        // These are not TempFolderItem instances, so they need separate handling.
+        if (editorGroupItems.length > 0) {
+            for (const item of editorGroupItems) {
+                const files = this.provider.getEditorGroupFiles(item.viewColumn);
+                for (const uri of files) {
+                    uriSet.add(uri);
+                }
+            }
         }
 
         if (uriSet.size > 0) {

--- a/src/dragAndDrop.ts
+++ b/src/dragAndDrop.ts
@@ -2,17 +2,20 @@ import * as vscode from 'vscode';
 import { TempFoldersProvider } from './provider';
 import { TempFolderItem, TempFileItem, ScopeHeaderItem } from './treeItems';
 import { I18n } from './i18n';
+import { extractDataTransferFileUris, parseUriList, uniqueUriStrings } from './core/DropUriParser';
 
 // Drag-and-drop controller, allows files to be dragged into groups AND groups to be nested
 export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropController<vscode.TreeItem> {
     constructor(private provider: TempFoldersProvider) { }
 
     public readonly supportedTypes = [
+        'files',
         'text/uri-list',
         'application/vnd.code.tree.virtualTabsView',
         'application/vnd.code.tree.virtualTabsView.files'
     ];
     public readonly dropMimeTypes = [
+        'files',
         'text/uri-list',
         'application/vnd.code.tree.virtualTabsView',
         'application/vnd.code.tree.virtualTabsView.files'
@@ -88,21 +91,23 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
             }
         }
 
-        // Priority 2: Check for external file drag (uri-list)
-        // Condition: uri-list exists AND we did NOT successfully extract internal file items
+        // Priority 2: Check for external file drag.
+        // Condition: external URIs exist AND we did NOT successfully extract internal file items
         // Note: We do NOT use `!fileData` because fileData may exist but contain an invalid/serialized value
         const uriList = dataTransfer.get('text/uri-list');
-        if (uriList && !draggedFiles) {
+        const uriListText = uriList ? await this.readDataTransferString(uriList) : undefined;
+        const externalUris = uniqueUriStrings([
+            ...parseUriList(uriListText),
+            ...this.extractExternalFileUris(dataTransfer)
+        ]);
+        if (externalUris.length > 0 && !draggedFiles) {
             const targetGroup = this.determineTargetGroup(target);
             if (targetGroup || target instanceof ScopeHeaderItem) {
-                // Fix: support both \n and \r\n, trim whitespace and control characters from each URI
-                const uris = uriList.value.split(/\r?\n/).map((s: string) => s.trim()).filter(Boolean);
-
                 // Expand directories to get all files
                 const allFileUris: string[] = [];
-                for (const uriStr of uris) {
+                for (const uriStr of externalUris) {
                     try {
-                        const uri = vscode.Uri.parse(uriStr);
+                        const uri = this.toDroppedUri(uriStr);
                         const stat = await vscode.workspace.fs.stat(uri);
 
                         if (stat.type === vscode.FileType.Directory) {
@@ -111,7 +116,7 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
                             allFileUris.push(...filesInDir.map(f => f.toString()));
                         } else if (stat.type === vscode.FileType.File) {
                             // It's a file - add directly
-                            allFileUris.push(uriStr);
+                            allFileUris.push(uri.toString());
                         }
                     } catch (e) {
                         // If we can't stat it, try adding it directly (might be a valid file)
@@ -170,6 +175,32 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
         if (!allAreFileItems) return null;
 
         return value as TempFileItem[];
+    }
+
+    private async readDataTransferString(item: vscode.DataTransferItem): Promise<unknown> {
+        try {
+            return await item.asString();
+        } catch {
+            return item.value;
+        }
+    }
+
+    private extractExternalFileUris(dataTransfer: vscode.DataTransfer): string[] {
+        const files: vscode.DataTransferFile[] = [];
+        for (const [, item] of dataTransfer) {
+            const file = item.asFile();
+            if (file) {
+                files.push(file);
+            }
+        }
+        return extractDataTransferFileUris(files);
+    }
+
+    private toDroppedUri(uriStr: string): vscode.Uri {
+        if (/^[a-zA-Z]:[\\/]/.test(uriStr) || uriStr.startsWith('\\\\') || uriStr.startsWith('/')) {
+            return vscode.Uri.file(uriStr);
+        }
+        return vscode.Uri.parse(uriStr);
     }
 
     private determineTargetGroup(target: vscode.TreeItem | undefined): TempFolderItem | undefined {

--- a/src/dragAndDrop.ts
+++ b/src/dragAndDrop.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { TempFoldersProvider } from './provider';
 import { TempFolderItem, TempFileItem, ScopeHeaderItem } from './treeItems';
 import { I18n } from './i18n';
-import { extractDataTransferFileUris, parseUriList, uniqueUriStrings } from './core/DropUriParser';
+import { extractDataTransferFileUris, formatDraggedFilesPlainText, parseUriList, uniqueUriStrings } from './core/DropUriParser';
 
 // Drag-and-drop controller, allows files to be dragged into groups AND groups to be nested
 export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropController<vscode.TreeItem> {
@@ -21,6 +21,7 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
         'application/vnd.code.tree.virtualTabsView.files'
     ];
     public readonly dragMimeTypes = [
+        'text/plain',
         'text/uri-list',
         'application/vnd.code.tree.virtualTabsView',
         'application/vnd.code.tree.virtualTabsView.files'
@@ -60,6 +61,7 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
             const uriList = Array.from(uriSet).join('\r\n');
             // Set drag data
             dataTransfer.set('text/uri-list', new vscode.DataTransferItem(uriList));
+            dataTransfer.set('text/plain', new vscode.DataTransferItem(this.createDraggedFilesPlainText(Array.from(uriSet))));
         }
     }
 
@@ -201,6 +203,19 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
             return vscode.Uri.file(uriStr);
         }
         return vscode.Uri.parse(uriStr);
+    }
+
+    private createDraggedFilesPlainText(uriStrings: readonly string[]): string {
+        const paths = uriStrings.map(uriString => {
+            try {
+                const uri = vscode.Uri.parse(uriString);
+                return vscode.workspace.asRelativePath(uri, false);
+            } catch {
+                return uriString;
+            }
+        });
+
+        return formatDraggedFilesPlainText(paths);
     }
 
     private determineTargetGroup(target: vscode.TreeItem | undefined): TempFolderItem | undefined {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -702,6 +702,16 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
     }
 
     /**
+     * Get the file URI strings for a specific editor group by viewColumn.
+     * Used by the drag controller to collect files when dragging EditorGroupItem nodes
+     * without directly accessing the private builtInEditorGroups array.
+     */
+    getEditorGroupFiles(viewColumn: number): string[] {
+        const eg = this.builtInEditorGroups.find(g => g.viewColumn === viewColumn);
+        return eg ? [...eg.files] : [];
+    }
+
+    /**
      * Returns true if the new editor group snapshot differs from the current one
      * in either count, column assignment, or file distribution.
      * Matches groups by viewColumn (not array index) to handle reordering correctly.

--- a/src/test/unit/DropUriParser.test.ts
+++ b/src/test/unit/DropUriParser.test.ts
@@ -1,4 +1,4 @@
-import { extractDataTransferFileUris, parseUriList, uniqueUriStrings } from '../../core/DropUriParser';
+import { extractDataTransferFileUris, formatDraggedFilesPlainText, parseUriList, uniqueUriStrings } from '../../core/DropUriParser';
 
 describe('DropUriParser', () => {
     test('parses text/uri-list with comments, blank lines, and CRLF', () => {
@@ -40,5 +40,20 @@ describe('DropUriParser', () => {
             'file:///workspace/a.ts',
             'file:///workspace/b.ts'
         ]);
+    });
+
+    test('formats dragged files as chat-friendly file references', () => {
+        expect(formatDraggedFilesPlainText([
+            'src/extension.ts',
+            'src/dragAndDrop.ts'
+        ])).toBe([
+            'Use these files as context:',
+            '#file:src/extension.ts',
+            '#file:src/dragAndDrop.ts'
+        ].join('\n'));
+    });
+
+    test('returns empty text when no dragged files are present', () => {
+        expect(formatDraggedFilesPlainText([])).toBe('');
     });
 });

--- a/src/test/unit/DropUriParser.test.ts
+++ b/src/test/unit/DropUriParser.test.ts
@@ -1,0 +1,44 @@
+import { extractDataTransferFileUris, parseUriList, uniqueUriStrings } from '../../core/DropUriParser';
+
+describe('DropUriParser', () => {
+    test('parses text/uri-list with comments, blank lines, and CRLF', () => {
+        const result = parseUriList([
+            '# copied from explorer',
+            'file:///workspace/project/src/index.ts',
+            '',
+            ' file:///workspace/project/package.json ',
+            ''
+        ].join('\r\n'));
+
+        expect(result).toEqual([
+            'file:///workspace/project/src/index.ts',
+            'file:///workspace/project/package.json'
+        ]);
+    });
+
+    test('returns no URIs for non-string uri-list values', () => {
+        expect(parseUriList(undefined)).toEqual([]);
+        expect(parseUriList(['file:///tmp/a.ts'])).toEqual([]);
+    });
+
+    test('extracts URI strings from DataTransferFile-like entries', () => {
+        const result = extractDataTransferFileUris([
+            { uri: { toString: () => 'file:///workspace/project' } },
+            { uri: undefined },
+            { uri: { toString: () => '' } }
+        ]);
+
+        expect(result).toEqual(['file:///workspace/project']);
+    });
+
+    test('deduplicates URI strings while preserving first-seen order', () => {
+        expect(uniqueUriStrings([
+            'file:///workspace/a.ts',
+            'file:///workspace/b.ts',
+            'file:///workspace/a.ts'
+        ])).toEqual([
+            'file:///workspace/a.ts',
+            'file:///workspace/b.ts'
+        ]);
+    });
+});

--- a/src/test/unit/dragHandleGroups.test.ts
+++ b/src/test/unit/dragHandleGroups.test.ts
@@ -1,0 +1,179 @@
+/**
+ * 單元測試：handleDrag 的 group/editor-group 拖曳收集邏輯
+ *
+ * 驗證：
+ * 1. builtIn group 現在可以產生拖曳 payload（不再被跳過）
+ * 2. EditorGroupItem 的檔案能正確被收集
+ * 3. 沒有 id 的 group 仍然被跳過
+ */
+
+// ─── 模擬資料結構 ──────────────────────────────────────────────────
+
+interface FakeGroup {
+    id: string;
+    name: string;
+    files?: string[];
+    builtIn?: boolean;
+    parentGroupId?: string;
+}
+
+/**
+ * 模擬 collectGroupFilesRecursive 的核心邏輯：
+ * 從指定 groupId 遞迴收集所有檔案。
+ */
+function collectGroupFilesRecursive(groups: FakeGroup[], groupId: string): string[] {
+    const files: string[] = [];
+    const visited = new Set<string>();
+
+    const walk = (id: string) => {
+        if (visited.has(id)) return;
+        visited.add(id);
+
+        const group = groups.find(g => g.id === id);
+        if (!group) return;
+
+        if (group.files) {
+            files.push(...group.files);
+        }
+
+        const children = groups.filter(g => g.parentGroupId === id);
+        for (const child of children) {
+            if (child.id) {
+                walk(child.id);
+            }
+        }
+    };
+
+    walk(groupId);
+    return files;
+}
+
+/**
+ * 模擬 handleDrag 中 groupItems 的收集邏輯（修正後版本）。
+ * builtIn group 不再被跳過；只跳過沒有 id 的 group。
+ */
+function collectDraggedGroupFiles(
+    groups: FakeGroup[],
+    draggedGroupIndices: number[]
+): string[] {
+    const uriSet = new Set<string>();
+
+    for (const groupIdx of draggedGroupIndices) {
+        const group = groups[groupIdx];
+        if (!group || !group.id) continue; // 只跳過沒有 id 的 group
+        const groupFiles = collectGroupFilesRecursive(groups, group.id);
+        for (const uri of groupFiles) {
+            uriSet.add(uri);
+        }
+    }
+
+    return Array.from(uriSet);
+}
+
+/**
+ * 模擬 EditorGroupItem 收集邏輯。
+ * 從 editorGroups 中找到對應 viewColumn 的 files。
+ */
+function collectEditorGroupFiles(
+    editorGroups: Array<{ viewColumn: number; files: string[] }>,
+    draggedViewColumns: number[]
+): string[] {
+    const uriSet = new Set<string>();
+
+    for (const viewColumn of draggedViewColumns) {
+        const eg = editorGroups.find(g => g.viewColumn === viewColumn);
+        if (eg) {
+            for (const uri of eg.files) {
+                uriSet.add(uri);
+            }
+        }
+    }
+
+    return Array.from(uriSet);
+}
+
+// ─── 測試 ─────────────────────────────────────────────────────────────────────
+
+describe('handleDrag group 收集邏輯', () => {
+    const groups: FakeGroup[] = [
+        {
+            id: 'builtin-1',
+            name: 'Currently Open Files',
+            files: ['file:///workspace/a.ts', 'file:///workspace/b.ts'],
+            builtIn: true
+        },
+        {
+            id: 'custom-1',
+            name: 'My Group',
+            files: ['file:///workspace/c.ts']
+        },
+        {
+            id: 'child-1',
+            name: 'Child Group',
+            files: ['file:///workspace/d.ts'],
+            parentGroupId: 'custom-1'
+        }
+    ];
+
+    test('builtIn group 拖曳時應能產生 payload', () => {
+        const result = collectDraggedGroupFiles(groups, [0]);
+        expect(result).toContain('file:///workspace/a.ts');
+        expect(result).toContain('file:///workspace/b.ts');
+    });
+
+    test('自訂 group 拖曳應正常收集檔案（含子群組）', () => {
+        const result = collectDraggedGroupFiles(groups, [1]);
+        expect(result).toContain('file:///workspace/c.ts');
+        expect(result).toContain('file:///workspace/d.ts');
+    });
+
+    test('沒有 id 的 group 仍應被跳過', () => {
+        const groupsWithNoId: FakeGroup[] = [
+            { id: '', name: 'Bad Group', files: ['file:///workspace/x.ts'] }
+        ];
+        const result = collectDraggedGroupFiles(groupsWithNoId, [0]);
+        expect(result).toEqual([]);
+    });
+
+    test('多個 group 同時拖曳時 URI 應正確去重', () => {
+        const groupsWithOverlap: FakeGroup[] = [
+            { id: 'g1', name: 'G1', files: ['file:///workspace/shared.ts', 'file:///workspace/a.ts'] },
+            { id: 'g2', name: 'G2', files: ['file:///workspace/shared.ts', 'file:///workspace/b.ts'] }
+        ];
+        const result = collectDraggedGroupFiles(groupsWithOverlap, [0, 1]);
+        expect(result).toHaveLength(3);
+        expect(result).toContain('file:///workspace/shared.ts');
+        expect(result).toContain('file:///workspace/a.ts');
+        expect(result).toContain('file:///workspace/b.ts');
+    });
+});
+
+describe('EditorGroupItem 拖曳收集邏輯', () => {
+    const editorGroups = [
+        { viewColumn: 1, files: ['file:///workspace/left.ts', 'file:///workspace/shared.ts'] },
+        { viewColumn: 2, files: ['file:///workspace/right.ts', 'file:///workspace/shared.ts'] }
+    ];
+
+    test('應收集指定 viewColumn 的所有檔案', () => {
+        const result = collectEditorGroupFiles(editorGroups, [1]);
+        expect(result).toEqual(['file:///workspace/left.ts', 'file:///workspace/shared.ts']);
+    });
+
+    test('多個 EditorGroupItem 同時拖曳時應去重', () => {
+        const result = collectEditorGroupFiles(editorGroups, [1, 2]);
+        expect(result).toHaveLength(3);
+        expect(result).toContain('file:///workspace/left.ts');
+        expect(result).toContain('file:///workspace/right.ts');
+        expect(result).toContain('file:///workspace/shared.ts');
+    });
+
+    test('不存在的 viewColumn 應回傳空結果', () => {
+        const result = collectEditorGroupFiles(editorGroups, [99]);
+        expect(result).toEqual([]);
+    });
+
+    test('空的 editor groups 陣列應回傳空結果', () => {
+        const result = collectEditorGroupFiles([], [1]);
+        expect(result).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- advertise the special iles drop MIME type for the VirtualTabs tree
- read external DataTransferFile URIs in addition to 	ext/uri-list
- normalize plain filesystem paths before directory expansion
- add 	ext/plain drag data for VirtualTabs file/group drags so AI chat sidebars such as GitHub Copilot can receive readable #file: references when they do not consume 	ext/uri-list
- bump the extension to 