### PR TITLE
[Routine - VT] fix: set up FileSystemWatchers for scopes added after workspace folder change

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,12 +236,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // 為每個 ConfigScope 建立 FileSystemWatcher（多 scope 支援）
     setupWatchers(provider.configScopes, provider, context);
+    const watchedScopeIds = new Set<string>(provider.configScopes.map(s => s.id));
 
     // 監聽工作區資料夾動態變更（新增/移除 folder）
     context.subscriptions.push(
         vscode.workspace.onDidChangeWorkspaceFolders(() => {
             // 重新執行 discovery 並更新 provider 的 configScopes
             provider.reinitializeScopes();
+            // 為新增的 scope 建立 FileSystemWatcher（避免重複建立已有的）
+            const newScopes = provider.configScopes.filter(s => !watchedScopeIds.has(s.id));
+            if (newScopes.length > 0) {
+                setupWatchers(newScopes, provider, context);
+                newScopes.forEach(s => watchedScopeIds.add(s.id));
+            }
         })
     );
 }


### PR DESCRIPTION
## Pre-flight Check

Active branches / open PRs checked before this fix:
- `origin/routine/vt-fix-duplicate-scope-260625` (PR #67) — touches `src/commands.ts`, `src/core/DropUriParser.ts`, `src/dragAndDrop.ts`, `src/provider.ts`
- `origin/fix/issue-60-folder-drop-files-mime` — touches `src/core/DropUriParser.ts`, `src/dragAndDrop.ts`, `src/provider.ts`

**This PR only modifies `src/extension.ts`, which is untouched by all active branches — no conflicts.**

## Changes

**File:** `src/extension.ts`

When `onDidChangeWorkspaceFolders` fires, `provider.reinitializeScopes()` correctly refreshes `provider.configScopes` with newly added workspace folders. However, `setupWatchers()` was only called once at extension activation — new scopes had no `FileSystemWatcher` monitoring their `virtualTab.json`. Externally-edited config files in dynamically added folders would not auto-refresh the tree view.

**Fix:** After `reinitializeScopes()`, filter `provider.configScopes` to find scopes that don't yet have a watcher, and call `setupWatchers` only for those new scopes. A `Set<string>` (`watchedScopeIds`) tracks which scope IDs already have watchers to prevent duplicate registrations.

```diff
+    const watchedScopeIds = new Set<string>(provider.configScopes.map(s => s.id));

     context.subscriptions.push(
         vscode.workspace.onDidChangeWorkspaceFolders(() => {
             provider.reinitializeScopes();
+            const newScopes = provider.configScopes.filter(s => !watchedScopeIds.has(s.id));
+            if (newScopes.length > 0) {
+                setupWatchers(newScopes, provider, context);
+                newScopes.forEach(s => watchedScopeIds.add(s.id));
+            }
         })
     );
```

## Safety Verification

- **`tsc --noEmit`**: No errors.
- **`npm test`**: 473/473 tests pass. The 1 suite-level failure is a pre-existing TypeScript symbol collision between two git worktrees (`busy-yalow-edb734` and `trusting-vaughan-0206eb`) — unrelated to this change.
- **No `package.json` commands, configuration keys, or serialization format changed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)