### PR TITLE
[Routine - VT] fix(GroupManager): return structuredClone on cache-miss path to prevent cache corruption

### DIFF
--- a/src/core/GroupManager.ts
+++ b/src/core/GroupManager.ts
@@ -74,7 +74,9 @@ export class GroupManager {
       this.cachedGroups = groups;
       this.lastModified = stats.mtimeMs;
 
-      return { groups, version: stats.mtimeMs };
+      // Return a clone so callers cannot corrupt the cache through shared mutation.
+      // Mirrors the structuredClone on the cache-hit path above.
+      return { groups: structuredClone(groups), version: stats.mtimeMs };
     } catch (error) {
       if (error instanceof SyntaxError) {
         this.handleCorruptedConfig();

--- a/src/test/unit/groupManagerCacheIsolation.test.ts
+++ b/src/test/unit/groupManagerCacheIsolation.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit test: GroupManager.loadGroups() cache isolation on cache-miss path.
+ *
+ * Verifies that mutating the array returned by loadGroups() on a cache-miss
+ * does NOT corrupt the internal cache, so a subsequent cache-hit call still
+ * returns the original on-disk data.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GroupManager } from '../../core/GroupManager';
+import type { TempGroup } from '../../types';
+
+function makeTempWorkspace(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vt-test-'));
+    fs.mkdirSync(path.join(dir, '.vscode'));
+    return dir;
+}
+
+function writeConfig(dir: string, groups: TempGroup[]): void {
+    fs.writeFileSync(
+        path.join(dir, '.vscode', 'virtualTab.json'),
+        JSON.stringify(groups, null, 2),
+        'utf8'
+    );
+}
+
+describe('GroupManager — cache isolation', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = makeTempWorkspace();
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('mutating the cache-miss result does not corrupt subsequent cache-hit reads', () => {
+        const initial: TempGroup[] = [{ id: 'g1', name: 'Group 1', files: ['a.ts'] }];
+        writeConfig(tmpDir, initial);
+
+        const manager = new GroupManager(tmpDir);
+
+        // First call: cache miss — reads from disk
+        const { groups: first } = manager.loadGroups();
+        expect(first).toHaveLength(1);
+
+        // Mutate the returned array without calling saveGroups
+        first.push({ id: 'ghost', name: 'Ghost Group', files: [] });
+        first[0].files = [];
+
+        // Second call: cache hit (mtime unchanged) — must reflect the on-disk state, not the mutation
+        const { groups: second } = manager.loadGroups();
+        expect(second).toHaveLength(1);
+        expect(second[0].id).toBe('g1');
+        expect(second[0].files).toEqual(['a.ts']);
+    });
+
+    test('each loadGroups call returns an independent copy', () => {
+        const initial: TempGroup[] = [{ id: 'g1', name: 'Group 1', files: ['a.ts'] }];
+        writeConfig(tmpDir, initial);
+
+        const manager = new GroupManager(tmpDir);
+
+        const { groups: a } = manager.loadGroups();
+        const { groups: b } = manager.loadGroups();
+
+        // Must be distinct object references
+        expect(a).not.toBe(b);
+        expect(a[0]).not.toBe(b[0]);
+    });
+});


### PR DESCRIPTION
## Pre-flight Check

Active branches / open PRs checked before this fix was written:

| PR / Branch | Touched files |
|---|---|
| PR #68 `routine/vt-fix-watcher-new-scope-260627` | `src/extension.ts` |
| PR #67 `routine/vt-fix-duplicate-scope-260625` | `src/commands.ts`, `src/provider.ts`, `src/dragAndDrop.ts`, `src/core/DropUriParser.ts` |
| `Ferezoz/fix/multi-root-workspace-detection` | `src/extension.ts`, `src/provider.ts`, `src/util.ts` |
| `jianfulin/feature/transmit` + variants | `src/commands.ts`, `src/types.ts`, `src/transmit.ts` |

**This PR only modifies `src/core/GroupManager.ts` and adds a new test file.** No overlap with any active branch or open PR.

---

## Changes

**`src/core/GroupManager.ts` — `loadGroups()`, cache-miss path (1 line change)**

Before:
```ts
return { groups, version: stats.mtimeMs };
```

After:
```ts
// Return a clone so callers cannot corrupt the cache through shared mutation.
// Mirrors the structuredClone on the cache-hit path above.
return { groups: structuredClone(groups), version: stats.mtimeMs };
```

**Root cause:** On a cache-miss, `loadGroups()` stored `groups` in `this.cachedGroups` and then returned the same reference to the caller. If the caller mutated the returned array before calling `saveGroups()` (e.g. `FileManager.addFilesToGroup` unconditionally assigns `group.files = []` before checking whether any files were actually added), the internal cache would reflect those mutations even though they were never persisted to disk. A subsequent cache-hit call would then return the stale in-memory state rather than the true on-disk data.

The cache-hit path already returned `structuredClone(cachedGroups)`. This fix applies the same defensive clone to the cache-miss path, making both paths consistent.

**`src/test/unit/groupManagerCacheIsolation.test.ts` — 2 new tests**

- Verifies that mutating the cache-miss result does not affect a subsequent cache-hit read.
- Verifies that each `loadGroups()` call returns an independent object copy.

---

## Safety Verification

```
> virtual-tabs@0.7.5 test
> tsc -p ./ && jest --runInBand

Test Suites: 24 passed, 24 total
Tests:       162 passed, 162 total
Snapshots:   0 total
Time:        8.943 s
Ran all test suites.
```

No lint/format scripts exist in this project (`npm run lint` and `npm run format` both return "missing script" — confirmed).