### PR TITLE
chore: support routine maintenance PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,22 @@ Before submitting this PR, please ensure you have read the [CONTRIBUTING.md](../
 Please check the items you have verified locally:
 
 - [ ] Code compiles properly without errors (`npm run vscode:prepublish`)
+- [ ] Unit/property tests pass (`npm run test:coverage`)
 - [ ] Fully tested and working in the Extension Development Host
 - [ ] Original functionality (e.g., grouping, drag-and-drop, context menus) is not broken by this PR
 - [ ] If new text is added, relevant `i18n` language files have been updated
+
+### 🤖 Routine PR Notes
+
+For daily routine Draft PRs:
+
+- [ ] This PR does not bump `package.json` or `package-lock.json`
+- [ ] This PR does not update `CHANGELOG.md`
+- [ ] This PR does not rename, add, or delete command registrations or contributed configuration keys
+- [ ] This PR does not modify tab-group serialization or storage format
+- [ ] Package version bump and changelog updates are deferred to the weekend release/integration PR
+
+Label the PR `release-ready` only when version and changelog updates are intentionally included.
 
 ### 📸 Screenshots or Screen Recordings (Optional)
 >

--- a/.github/workflows/label-routine-pr.yml
+++ b/.github/workflows/label-routine-pr.yml
@@ -1,0 +1,25 @@
+name: Label Routine PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  label-routine:
+    if: startsWith(github.event.pull_request.title, '[Routine - VT]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add routine label
+        run: gh pr edit "$PR_URL" --add-label routine
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,13 @@ name: Validate Extension
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
     branches:
       - main
   push:
@@ -31,8 +38,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate version bump
-        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      - name: Validate release version bump
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'release-ready')
         run: |
           git fetch origin "${{ github.base_ref }}"
           changed_files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ test-results/
 test-ui-output.txt
 docs/assets/fix_rounded_corners.py
 docs/_archive/**
+routine_fail.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+- 任務報告或規劃文件皆優先以中文撰寫。
+- Daily routine Draft PR 不做 release 準備：不要 bump `package.json` / `package-lock.json`，不要更新 `CHANGELOG.md`。
+- 不可 rename、add、delete `package.json` 內 contributed command registrations 或 configuration keys，除非使用者明確要求 release-facing breaking/change work。
+- 不可修改 tab-group serialization format 或 configuration storage logic，避免破壞既有使用者資料。
+- 文件修正不可只改使用者指出的單一檔案。若問題屬於同源文案、release-facing docs、README、多語文件或 llms 文件，必須先用 `rg` 掃 `README.md`、`docs/`、`llms*.txt` 找出同類問題，列出 scope 後一起修正，改完再反向 `rg` 驗證舊口徑不存在。

--- a/docs/maintainer-routine.md
+++ b/docs/maintainer-routine.md
@@ -1,0 +1,37 @@
+# Maintainer Routine
+
+This repository supports small daily routine Draft PRs and separate weekend release/integration PRs.
+
+## Daily Routine Draft PRs
+
+Daily routine PRs should stay small and easy to review.
+
+- Fix one small, safe issue.
+- Avoid duplicate work by checking open PRs and active routine branches first.
+- Do not bump `package.json` or `package-lock.json`.
+- Do not update `CHANGELOG.md`.
+- Do not rename, add, or delete command registrations or contributed configuration keys.
+- Do not modify tab-group serialization or storage format.
+- Do not add, remove, or update dependencies.
+- Keep the PR as Draft until it is intentionally selected for integration.
+
+Run local validation before opening the Draft PR:
+
+```powershell
+npx tsc -p ./
+npm run test
+npm run test:coverage
+```
+
+If a routine attempt fails after focused fixes, write the failure summary to `routine_fail.log`. That file is ignored by Git.
+
+## Release/Integration PRs
+
+Weekend release or integration PRs are responsible for release metadata.
+
+- Consolidate selected routine PRs.
+- Bump `package.json` and `package-lock.json` once.
+- Update `CHANGELOG.md`.
+- Add the `release-ready` label when the PR is ready for release version validation.
+
+The release version gate in CI runs only for pull requests labeled `release-ready`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,8 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     testMatch: ['**/src/test/**/*.test.ts'],
-    testPathIgnorePatterns: ['/node_modules/', '/src/test/ui/', '/.vscode-test/'],
-    modulePathIgnorePatterns: ['<rootDir>/.vscode-test/'],
+    testPathIgnorePatterns: ['/node_modules/', '/src/test/ui/', '/.vscode-test/', '/.claude/', '/.cursor/', '/.kiro/'],
+    modulePathIgnorePatterns: ['<rootDir>/.vscode-test/', '<rootDir>/.claude/', '<rootDir>/.cursor/', '<rootDir>/.kiro/'],
     transform: {
         '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }]
     },


### PR DESCRIPTION
## Summary

Adds repository support for daily routine maintenance PRs and separates release readiness from normal validation.

## Changes

- Runs the release version bump gate only when a PR has the \elease-ready\ label.
- Adds an automatic \outine\ label workflow for PR titles starting with \[Routine - VT]\.
- Adds VirtualTabs \AGENTS.md\ with routine PR and storage/command guardrails.
- Updates the PR template with routine maintenance checks.
- Adds maintainer routine documentation.
- Ignores \outine_fail.log\.
- Ignores local agent/worktree folders in Jest discovery.

## Safety Verification

- \git diff --check\ passed.
- \
px tsc -p ./\ passed.
- \
pm run test:coverage\ passed: 23 suites / 160 tests.

## Release Gate Note

Do not add \elease-ready\ to routine Draft PRs. Add it only to weekend release/integration PRs that intentionally include version and changelog updates.