### PR TITLE
ci: gate version bump on release-ready label

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,13 @@ name: Validate Extension
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
     branches:
       - main
   push:
@@ -32,7 +39,7 @@ jobs:
         run: npm ci
 
       - name: Validate version bump
-        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'release-ready')
         run: |
           git fetch origin "${{ github.base_ref }}"
           changed_files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")


### PR DESCRIPTION
## Summary

Make the version bump check run only when a PR is explicitly labeled release-ready.

## Scope

Only .github/workflows/validate.yml is changed.

## Why

Daily routine Draft PRs should still run normal validation, but should not be forced to bump package.json/package-lock.json before the weekend release/integration PR.

## Validation

- git diff --check passed.

## Review note

This PR is intentionally small and is not merged automatically.