### PR TITLE
[Routine - VT] fix(extension): dispose treeView listeners and pending reveal timer

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,32 +134,37 @@ export async function activate(context: vscode.ExtensionContext) {
         context.workspaceState.update(expandedKey, ids);
     };
 
-    treeView.onDidExpandElement(e => updateExpandedState(e.element, true));
-    treeView.onDidCollapseElement(e => updateExpandedState(e.element, false));
-
+    context.subscriptions.push(
+        treeView.onDidExpandElement(e => updateExpandedState(e.element, true)),
+        treeView.onDidCollapseElement(e => updateExpandedState(e.element, false))
+    );
 
     // Refresh the view when it becomes visible
-    treeView.onDidChangeVisibility(e => {
-        if (e.visible) {
-            provider.refresh();
-        }
-    });
+    context.subscriptions.push(
+        treeView.onDidChangeVisibility(e => {
+            if (e.visible) {
+                provider.refresh();
+            }
+        })
+    );
 
     // Update context key based on selection; also track last selected custom file for keybindings
     let lastSelectedCustomFile: TempFileItem | undefined;
-    treeView.onDidChangeSelection(e => {
-        const hasFile = e.selection.some(item => item instanceof TempFileItem);
-        const customFileItem = e.selection.find((item): item is TempFileItem =>
-            item instanceof TempFileItem &&
-            !!item.contextValue &&
-            item.contextValue.includes('virtualTabsFileCustom')
-        );
-        if (customFileItem) {
-            lastSelectedCustomFile = customFileItem;
-        }
-        vscode.commands.executeCommand('setContext', 'virtualTabs:hasFileSelected', hasFile);
-        vscode.commands.executeCommand('setContext', 'virtualTabs:hasCustomFileSelected', !!customFileItem);
-    });
+    context.subscriptions.push(
+        treeView.onDidChangeSelection(e => {
+            const hasFile = e.selection.some(item => item instanceof TempFileItem);
+            const customFileItem = e.selection.find((item): item is TempFileItem =>
+                item instanceof TempFileItem &&
+                !!item.contextValue &&
+                item.contextValue.includes('virtualTabsFileCustom')
+            );
+            if (customFileItem) {
+                lastSelectedCustomFile = customFileItem;
+            }
+            vscode.commands.executeCommand('setContext', 'virtualTabs:hasFileSelected', hasFile);
+            vscode.commands.executeCommand('setContext', 'virtualTabs:hasCustomFileSelected', !!customFileItem);
+        })
+    );
 
 
     // Listen for active editor change to auto-reveal file in the Virtual Tabs panel.
@@ -222,6 +227,15 @@ export async function activate(context: vscode.ExtensionContext) {
             }, 100);
         })
     );
+
+    // Ensure the debounce timer doesn't fire against a disposed tree view on deactivation
+    context.subscriptions.push({
+        dispose: () => {
+            if (revealTimeout) {
+                clearTimeout(revealTimeout);
+            }
+        }
+    });
 
     // Listen for editor file open/close events to auto-refresh the tree view
     // Only use syncBuiltInGroup here to avoid recreating the entire tree when switching tabs


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs at the time of this run:
- #76 `chore: release v0.7.6` (`release/0.7.6-260701` → `main`, not draft) — touches only `CHANGELOG.md`, `package.json`, `package-lock.json`.

Active/remote branches inspected: various `origin/routine/vt-fix-*` branches (all already merged into `main`, confirmed via `git log --all`), plus unrelated fork branches (`Ferezoz/*`, `jianfulin/*`) not touching this repo's open PR set.

This PR only changes `src/extension.ts` (treeView listener registration and a debounce-timer disposal), which does not overlap with PR #76's release-metadata-only diff or any other active branch.

## 2. Changes

- Wrapped `treeView.onDidExpandElement`, `treeView.onDidCollapseElement`, `treeView.onDidChangeVisibility`, and the first `treeView.onDidChangeSelection` listener registrations in `context.subscriptions.push(...)` so they are explicitly disposed on extension deactivation (previously only a second, duplicate `onDidChangeSelection` listener was disposed).
- Registered a disposable that clears the debounced `revealTimeout` (`setTimeout`) used for auto-revealing the active file, so a pending timer callback cannot fire against an already-disposed `treeView` after deactivation.

Confirmed this PR does **not**:
- Add/remove/rename any VS Code command registrations.
- Add/remove/rename any contributed configuration keys in `package.json`.
- Modify dependencies or `package.json`/`package-lock.json`.
- Touch tab-group serialization or config storage format.

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` → passed, no errors.
- `npm run test` (runs `tsc -p ./ && jest --runInBand`) → 25 suites / 175 tests passed.

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine-task instructions.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's release-readiness/version-bump gate, that is expected behavior for a routine PR, not a code validation failure.