### PR TITLE
[Routine - VT] fix(provider): guard against stale groupIdx when rendering file bookmarks

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1852,6 +1852,9 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         // If it's a file node, show bookmarks (v0.2.0)
         if (element instanceof TempFileItem) {
             const group = this.groups[element.groupIdx];
+            // Safety check: groupIdx might be stale if the groups array shifted
+            // (e.g. a group was removed/reordered) before this node re-rendered.
+            if (!group) return [];
             const bookmarks = BookmarkManager.getBookmarksForFile(
                 group,
                 element.uri.toString()


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs / active branches checked before starting:
- **PR #77** `routine/vt-fix-treeview-listener-disposal-260702` — touches `src/extension.ts` only (treeView listener/reveal-timer disposal).
- **PR #76** `release/0.7.6-260701` — touches `package.json`, `package-lock.json`, `CHANGELOG.md` only (release PR).
- Several stale `origin/routine/vt-fix-*` branches exist but their commits are already squash-merged into `main` (confirmed via `git log`), and `gh pr list --state open` shows no PR for them.

This PR only touches `src/provider.ts`, which none of the above modify — no overlap.

## 2. Changes

`TreeDataProvider.getChildren()` had a branch for `TempFileItem` that looked up `const group = this.groups[element.groupIdx]` and passed it directly into `BookmarkManager.getBookmarksForFile(group, ...)`, which unconditionally dereferences `group.bookmarks`. If `element.groupIdx` is stale (e.g. a group was removed via `removeGroupById` or reordered via `moveGroup`, shifting array indices) before this tree node re-renders, `group` is `undefined` and the call throws. The sibling `TempFolderItem` branch just above already has an `if (!group) return [];` guard for this exact stale-index scenario — this PR adds the equivalent guard for the `TempFileItem` branch.

Confirmed this PR does **not** modify commands, contributed configuration keys, dependencies, or the tab-group serialization/storage format.

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 25 suites / 175 tests passed

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG updates are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.