### PR TITLE
[Routine - VT] fix(FileManager): use normalized membership check for add/remove files

### DIFF
--- a/src/core/FileManager.ts
+++ b/src/core/FileManager.ts
@@ -8,6 +8,7 @@
 
 import { PathUtils } from './PathUtils.js';
 import { GroupManager } from './GroupManager.js';
+import { matchesStoredFileEntry } from './FileEntryMatcher.js';
 import { TempGroup } from '../types.js';
 
 /**
@@ -83,8 +84,10 @@ export class FileManager {
       }
 
       const fileUri = this.toFileUri(filePath);
+      const targetFsPath = this.toAbsolutePath(filePath);
+      const workspaceRoot = this.groupManager.getWorkspaceRoot();
 
-      if (group.files.includes(fileUri)) {
+      if (group.files.some(entry => matchesStoredFileEntry(entry, fileUri, targetFsPath, workspaceRoot))) {
         result.skipped.push(filePath);
         continue;
       }
@@ -120,9 +123,12 @@ export class FileManager {
       return result;
     }
 
+    const workspaceRoot = this.groupManager.getWorkspaceRoot();
+
     for (const filePath of filePaths) {
       const fileUri = this.toFileUri(filePath);
-      const index = group.files.indexOf(fileUri);
+      const targetFsPath = this.toAbsolutePath(filePath);
+      const index = group.files.findIndex(entry => matchesStoredFileEntry(entry, fileUri, targetFsPath, workspaceRoot));
 
       if (index === -1) {
         result.notFound.push(filePath);

--- a/src/test/unit/fileManagerRelpath.test.ts
+++ b/src/test/unit/fileManagerRelpath.test.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FileManager } from '../../core/FileManager';
+import { GroupManager } from '../../core/GroupManager';
+import type { TempGroup } from '../../types';
+
+describe('FileManager relative-path membership', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vt-fm-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function setupWorkspace(groups: TempGroup[]): { gm: GroupManager; fm: FileManager } {
+        fs.mkdirSync(path.join(tmpDir, '.vscode'), { recursive: true });
+        fs.writeFileSync(path.join(tmpDir, '.vscode', 'virtualTab.json'), JSON.stringify(groups));
+        const gm = new GroupManager(tmpDir);
+        const fm = new FileManager(tmpDir, gm);
+        return { gm, fm };
+    }
+
+    test('addFilesToGroup skips a file already stored as a workspace-relative path', () => {
+        const { fm, gm } = setupWorkspace([{
+            id: 'group-1',
+            name: 'Test Group',
+            files: ['src/foo.ts']
+        }]);
+
+        const result = fm.addFilesToGroup('group-1', [path.join(tmpDir, 'src', 'foo.ts')]);
+
+        expect(result.added).toEqual([]);
+        expect(result.skipped).toEqual([path.join(tmpDir, 'src', 'foo.ts')]);
+
+        const { groups } = gm.loadGroups();
+        expect(groups[0].files).toEqual(['src/foo.ts']);
+    });
+
+    test('removeFilesFromGroup removes a file stored as a workspace-relative path', () => {
+        const { fm, gm } = setupWorkspace([{
+            id: 'group-1',
+            name: 'Test Group',
+            files: ['src/foo.ts', 'src/bar.ts']
+        }]);
+
+        const result = fm.removeFilesFromGroup('group-1', [path.join(tmpDir, 'src', 'foo.ts')]);
+
+        expect(result.removed).toEqual([path.join(tmpDir, 'src', 'foo.ts')]);
+        expect(result.notFound).toEqual([]);
+
+        const { groups } = gm.loadGroups();
+        expect(groups[0].files).toEqual(['src/bar.ts']);
+    });
+
+    test('removeFilesFromGroup still reports notFound for genuinely absent files', () => {
+        const { fm } = setupWorkspace([{
+            id: 'group-1',
+            name: 'Test Group',
+            files: ['src/foo.ts']
+        }]);
+
+        const result = fm.removeFilesFromGroup('group-1', [path.join(tmpDir, 'src', 'missing.ts')]);
+
+        expect(result.removed).toEqual([]);
+        expect(result.notFound).toEqual([path.join(tmpDir, 'src', 'missing.ts')]);
+    });
+});


### PR DESCRIPTION
## Pre-flight Check

Open PRs / active branches checked before selecting this fix:
- #78 `routine/vt-fix-bookmark-stale-groupidx-260703` — touches `src/provider.ts`
- #77 `routine/vt-fix-treeview-listener-disposal-260702` — touches `src/extension.ts`
- #76 `release/0.7.6-260701` — touches `CHANGELOG.md`, `package.json`, `package-lock.json` (release PR, not routine)
- Various stale/merged `origin/routine/vt-fix-*` branches from prior days (bookmark-relpath, filesorter-tests, groupmgr-cache-miss, senddestguard, treeview-listener-disposal, watcher-new-scope, duplicate-scope) — already merged, no overlap.

This PR touches only `src/core/FileManager.ts` and adds a new test file `src/test/unit/fileManagerRelpath.test.ts`. No overlap with `provider.ts`, `extension.ts`, or any release metadata files.

## Changes

`FileManager.addFilesToGroup` and `FileManager.removeFilesFromGroup` compared file paths against `group.files` using plain `Array.includes()` / `Array.indexOf()` against a freshly-built `file://` URI. However, `group.files` can legitimately contain workspace-relative path strings (e.g. `"src/foo.ts"`) instead of `file://` URIs — this is the same class of bug already fixed for `BookmarkManager.createBookmark` in commit e12c0d9 via `matchesStoredFileEntry`.

Because these two `FileManager` methods back the MCP server's `add_files_to_group` / `remove_files_from_group` tools (`mcp-server/src/tools/fileTools.ts` → `mcp-server/src/managers/FileManager.ts`, a re-export of this class), the bug was reachable from the MCP-facing API even though the in-editor path (`provider.ts`) already uses the normalized matcher:
- `addFilesToGroup` would fail to recognize a relative-path entry as a duplicate and push a second (URI) entry for the same file instead of reporting it as `skipped`.
- `removeFilesFromGroup` would fail to find a relative-path entry and incorrectly report it as `notFound` instead of removing it.

Fix: both methods now use `matchesStoredFileEntry` (from `src/core/FileEntryMatcher.ts`) with the group's workspace root, matching the pattern already used by `BookmarkManager` and `GroupFileRemoval`.

Confirms this PR does **not** modify: command registrations, `package.json` contributed configuration keys, dependencies, or the tab-group serialization/storage format. Only comparison logic inside two existing methods changed; the on-disk `files` array shape and `virtualTab.json` format are untouched.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — passed, no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — **26 suites / 178 tests passed**, including 3 new tests in `src/test/unit/fileManagerRelpath.test.ts` covering: skip-on-duplicate for a relative-path entry, remove-by-relative-path entry, and notFound still reported for genuinely absent files.
- No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.