### PR TITLE
[Routine - VT] fix(commands): clamp bookmark position to document bounds in jumpToBookmark

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1188,10 +1188,13 @@ export function registerCommands(
                 const document = await vscode.workspace.openTextDocument(item.fileUri);
                 const editor = await vscode.window.showTextDocument(document);
 
-                const position = new vscode.Position(
+                // Clamp to the document's current bounds: the file may have been
+                // edited (lines removed) since the bookmark was created, which would
+                // otherwise leave selection/reveal operating on an invalid position.
+                const position = document.validatePosition(new vscode.Position(
                     item.bookmark.line,
                     item.bookmark.character || 0
-                );
+                ));
 
                 const range = new vscode.Range(position, position);
 


### PR DESCRIPTION
## Pre-flight Check

Open PRs / active branches checked before selecting this fix:
- #79 `routine/vt-fix-filemanager-relpath-260706` — touches `src/core/FileManager.ts`, `src/test/unit/fileManagerRelpath.test.ts`
- #78 `routine/vt-fix-bookmark-stale-groupidx-260703` — touches `src/provider.ts`
- #77 `routine/vt-fix-treeview-listener-disposal-260702` — touches `src/extension.ts`
- #76 `release/0.7.6-260701` — touches `CHANGELOG.md`, `package.json`, `package-lock.json`

This PR only modifies `src/commands.ts` (the `virtualTabs.jumpToBookmark` command handler), which is not touched by any of the above. No functional or textual overlap.

## Changes

`virtualTabs.jumpToBookmark` builds a `vscode.Position` directly from the stored `bookmark.line` / `bookmark.character` and immediately uses it for `editor.selection` and `editor.revealRange`. If the target file was edited outside VirtualTabs (e.g. lines removed) since the bookmark was recorded, the stored line/character can exceed the current document's bounds, so the editor ends up selecting/revealing an invalid position.

Fix: clamp the constructed `Position` with `document.validatePosition(...)` (the standard VS Code API for this) before building the range/selection, so the jump always lands on the closest valid position in the current document instead.

This PR does not:
- Add/rename/remove any command registrations, configuration keys, or dependencies.
- Modify `package.json` / `package-lock.json` / `CHANGELOG.md`.
- Touch tab-group serialization or storage/config logic.

## Safety Verification

Commands run locally, both passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 25 suites / 175 tests passed

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.