### PR TITLE
[Routine - VT] fix(AutoGrouper): move bookmarks to sub-groups on extension/date auto-grouping

### DIFF
--- a/src/core/AutoGrouper.ts
+++ b/src/core/AutoGrouper.ts
@@ -92,6 +92,31 @@ export class AutoGrouper {
     return Math.floor(Math.abs(d2.getTime() - d1.getTime()) / oneDay);
   }
 
+  /**
+   * Move each file's bookmarks from the source group to the newly created
+   * sub-group, mirroring the same-file-move logic in dragAndDrop.ts.
+   * Without this, bookmarks are orphaned on the (now empty) source group
+   * and become unreachable from the UI.
+   */
+  private static moveBookmarks(sourceGroup: TempGroup, targetGroup: TempGroup, fileUris: string[]): void {
+    if (!sourceGroup.bookmarks) return;
+
+    for (const fileUri of fileUris) {
+      const bookmarks = sourceGroup.bookmarks[fileUri];
+      if (!bookmarks) continue;
+
+      if (!targetGroup.bookmarks) {
+        targetGroup.bookmarks = {};
+      }
+      targetGroup.bookmarks[fileUri] = bookmarks;
+      delete sourceGroup.bookmarks[fileUri];
+    }
+
+    if (Object.keys(sourceGroup.bookmarks).length === 0) {
+      delete sourceGroup.bookmarks;
+    }
+  }
+
   // ─── Instance methods (MCP layer — load/mutate/save) ───
 
   /**
@@ -152,6 +177,8 @@ export class AutoGrouper {
         sourceGroupId: groupId
       };
 
+      AutoGrouper.moveBookmarks(sourceGroup, newGroup, uriList);
+
       groups.push(newGroup);
       createdGroups.push({
         id: newGroup.id,
@@ -209,6 +236,8 @@ export class AutoGrouper {
         autoGroupType: 'modifiedDate',
         sourceGroupId: groupId
       };
+
+      AutoGrouper.moveBookmarks(sourceGroup, newGroup, uriList);
 
       groups.push(newGroup);
       createdGroups.push({

--- a/src/test/unit/autoGrouperBookmarks.test.ts
+++ b/src/test/unit/autoGrouperBookmarks.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit test: AutoGrouper.groupByExtension() / groupByDate() must move each
+ * file's bookmarks to the newly created sub-group instead of leaving them
+ * orphaned on the (now empty) source group.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GroupManager } from '../../core/GroupManager';
+import { FileManager } from '../../core/FileManager';
+import { AutoGrouper } from '../../core/AutoGrouper';
+import type { TempGroup, VTBookmark } from '../../types';
+
+function makeTempWorkspace(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vt-autogroup-test-'));
+    fs.mkdirSync(path.join(dir, '.vscode'));
+    return dir;
+}
+
+function writeConfig(dir: string, groups: TempGroup[]): void {
+    fs.writeFileSync(
+        path.join(dir, '.vscode', 'virtualTab.json'),
+        JSON.stringify(groups, null, 2),
+        'utf8'
+    );
+}
+
+function makeBookmark(): VTBookmark {
+    return { id: 'bm-1', line: 0, label: 'Test Bookmark', created: Date.now() };
+}
+
+describe('AutoGrouper — bookmark migration on auto-grouping', () => {
+    let tmpDir: string;
+    let groupManager: GroupManager;
+    let fileManager: FileManager;
+    let autoGrouper: AutoGrouper;
+
+    beforeEach(() => {
+        tmpDir = makeTempWorkspace();
+        groupManager = new GroupManager(tmpDir);
+        fileManager = new FileManager(tmpDir, groupManager);
+        autoGrouper = new AutoGrouper(groupManager, fileManager);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('groupByExtension moves bookmarks to the new sub-group and clears the source', () => {
+        const tsUri = fileManager.toFileUri(path.join(tmpDir, 'a.ts'));
+        const jsonUri = fileManager.toFileUri(path.join(tmpDir, 'b.json'));
+
+        writeConfig(tmpDir, [{
+            id: 'g1',
+            name: 'Mixed',
+            files: [tsUri, jsonUri],
+            bookmarks: { [tsUri]: [makeBookmark()] }
+        }]);
+
+        const result = autoGrouper.groupByExtension('g1');
+        expect(result.created).toBe(2);
+
+        const { groups } = groupManager.loadGroups();
+        const source = groups.find(g => g.id === 'g1')!;
+        const tsGroup = groups.find(g => g.autoGroupType === 'extension' && g.files?.includes(tsUri))!;
+        const jsonGroup = groups.find(g => g.autoGroupType === 'extension' && g.files?.includes(jsonUri))!;
+
+        expect(source.bookmarks).toBeUndefined();
+        expect(tsGroup.bookmarks?.[tsUri]).toHaveLength(1);
+        expect(jsonGroup.bookmarks).toBeUndefined();
+    });
+
+    test('groupByDate moves bookmarks to the new sub-group and clears the source', () => {
+        const fileUri = fileManager.toFileUri(path.join(tmpDir, 'missing-file.ts'));
+
+        writeConfig(tmpDir, [{
+            id: 'g1',
+            name: 'Dated',
+            files: [fileUri],
+            bookmarks: { [fileUri]: [makeBookmark()] }
+        }]);
+
+        const result = autoGrouper.groupByDate('g1');
+        expect(result.created).toBe(1);
+
+        const { groups } = groupManager.loadGroups();
+        const source = groups.find(g => g.id === 'g1')!;
+        const dateGroup = groups.find(g => g.autoGroupType === 'modifiedDate')!;
+
+        expect(source.bookmarks).toBeUndefined();
+        expect(dateGroup.bookmarks?.[fileUri]).toHaveLength(1);
+    });
+
+    test('groupByExtension leaves source untouched when it has no bookmarks', () => {
+        const tsUri = fileManager.toFileUri(path.join(tmpDir, 'a.ts'));
+
+        writeConfig(tmpDir, [{
+            id: 'g1',
+            name: 'NoBookmarks',
+            files: [tsUri]
+        }]);
+
+        autoGrouper.groupByExtension('g1');
+
+        const { groups } = groupManager.loadGroups();
+        const tsGroup = groups.find(g => g.autoGroupType === 'extension')!;
+        expect(tsGroup.bookmarks).toBeUndefined();
+    });
+});
+
+export {};


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs / active branches checked before starting:
- **PR #80** `routine/vt-fix-jumptobookmark-clamp-260707` — touches `src/commands.ts` only.
- **PR #79** `routine/vt-fix-filemanager-relpath-260706` — touches `src/core/FileManager.ts` and its test file.
- **PR #78** `routine/vt-fix-bookmark-stale-groupidx-260703` — touches `src/provider.ts` only.
- **PR #77** `routine/vt-fix-treeview-listener-disposal-260702` — touches `src/extension.ts` only.
- **PR #76** `release/0.7.6-260701` — release PR, touches `package.json`/`package-lock.json`/`CHANGELOG.md` only.
- Numerous `origin/routine/vt-fix-*` branches are stale (already squash-merged into `main`, confirmed via `git log`) and have no open PR.

This PR only touches `src/core/AutoGrouper.ts` (plus a new test file), which none of the above modify — no overlap.

## 2. Changes

`AutoGrouper.groupByExtension()` and `AutoGrouper.groupByDate()` (the MCP-layer auto-grouping methods) move a source group's `files` into newly created sub-groups but never touched `sourceGroup.bookmarks`. After `sourceGroup.files = []`, any bookmarks keyed by the moved file URIs stayed attached to the now-empty source group — unreachable from the UI (which reads bookmarks from the file's actual containing group) and left to accumulate silently in the JSON store across repeated auto-grouping calls.

Added a `moveBookmarks()` private static helper that relocates each moved file's bookmark entries from the source group to its new sub-group and cleans up the empty `bookmarks` object, mirroring the existing move-with-file pattern already used in `dragAndDrop.ts`'s `handleFileDrop` (lines ~273-287). Added `src/test/unit/autoGrouperBookmarks.test.ts` covering: bookmarks migrate correctly on `groupByExtension`, on `groupByDate`, and that groups without bookmarks are left untouched.

Confirmed this PR does **not** modify commands, contributed configuration keys, dependencies, or the tab-group serialization/storage format (bookmarks already lived on `TempGroup.bookmarks` keyed by file URI — this only relocates existing entries to the correct group).

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 26 suites / 178 tests passed

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG updates are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.