### PR TITLE
[Routine - VT] fix(mcp): guard files iteration in validate_json_structure against undefined

### DIFF
--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -597,7 +597,7 @@ export class VirtualTabsMCPServer {
                 if (!g.name) { errors.push(`Group[${i}] missing "name".`); }
                 if (g.files !== undefined && !Array.isArray(g.files)) {
                   errors.push(`Group "${g.name ?? i}" has invalid "files" (expected array or undefined).`);
-                } else {
+                } else if (Array.isArray(g.files)) {
                   for (const f of g.files) {
                     if (path.isAbsolute(f)) {
                       errors.push(`Group "${g.name}": absolute path detected: "${f}". Must be workspace-relative.`);


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs checked (all Draft, all CLEAN merge status):
- #81 `routine/vt-fix-autogroup-bookmarks-260708` — touches `src/core/AutoGrouper.ts`, `src/test/unit/autoGrouperBookmarks.test.ts`
- #80 `routine/vt-fix-jumptobookmark-clamp-260707` — touches `src/commands.ts`
- #79 `routine/vt-fix-filemanager-relpath-260706` — touches `src/core/FileManager.ts`, `src/test/unit/fileManagerRelpath.test.ts`
- #78 `routine/vt-fix-bookmark-stale-groupidx-260703` — touches `src/provider.ts`
- #77 `routine/vt-fix-treeview-listener-disposal-260702` — touches `src/extension.ts`
- #76 `release/0.7.6-260701` — release PR (non-code-diff concern)

This PR touches only `mcp-server/src/server.ts`, which is not modified by any of the above. No overlap.

## 2. Changes

`validate_json_structure` (the MCP tool AI agents are told to call before any direct write to `.vscode/virtualTab.json`) validates each group's optional `files` field with:

```ts
if (g.files !== undefined && !Array.isArray(g.files)) {
  errors.push(...);
} else {
  for (const f of g.files) { ... }   // BUG: runs even when g.files is undefined
}
```

Since `files` is a legitimately optional field (per the tool's own JSON schema), any group without a `files` key hits the `else` branch and does `for (const f of undefined)`, throwing `TypeError: undefined is not iterable`. That exception is swallowed by the handler's outer `try/catch` and reported back to the AI agent as `"JSON parse error: ... is not iterable"` — a misleading false negative for perfectly valid, syntactically correct JSON.

Fix: only iterate `g.files` when it is actually an array (`else if (Array.isArray(g.files))`), matching the same predicate already used for the invalid-type check.

Confirms this PR does **not** modify commands, contributed configuration keys, dependencies, or the tab-group serialization/storage format. No `package.json`/`package-lock.json`/`CHANGELOG.md` changes.

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npx tsc -p ./mcp-server` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 25 suites / 175 tests passed
- `npm run build:mcp` (esbuild bundle sanity check) — succeeded
- Manual repro: extracted the validation logic and ran it against `[{ "id": "g1", "name": "Empty Group" }]` (no `files` key) — before the fix this throws; after the fix it returns `{ "valid": true, "errors": [], "warnings": [] }`

No `lint` or `format:check` npm scripts exist in this repo, so those steps were skipped per the routine-task instructions.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior, not a code validation failure.