### PR TITLE
[Routine - VT] fix(provider): flush pending debounced save on deactivation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,6 +117,10 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(treeView);
     treeView.description = provider.computeScopeDescription();
 
+    // Flush any pending debounced save on deactivation so a change made
+    // just before VS Code closes isn't lost.
+    context.subscriptions.push({ dispose: () => provider.flushPendingSave() });
+
     // Pass the tree view to the provider for selection management
     provider.setTreeView(treeView);
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -331,6 +331,20 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         }, 500);
     }
 
+    /**
+     * Synchronously flush a pending debounced save, if any.
+     * Call this on extension deactivation — otherwise an edit made just
+     * before VS Code closes can be lost, since the 500ms debounce timer
+     * never gets a chance to fire.
+     */
+    flushPendingSave(): void {
+        if (this.saveDebounceTimer) {
+            clearTimeout(this.saveDebounceTimer);
+            this.saveDebounceTimer = undefined;
+            this.saveGroupsImmediate();
+        }
+    }
+
     private saveGroupsImmediate() {
         if (this.groupManagers.size === 0) {
             console.warn('Cannot save VirtualTabs data: no GroupManagers available');


### PR DESCRIPTION
## Pre-flight Check

Open PRs / active routine branches checked before starting (Phase 1):

| PR | Branch | Files touched |
|----|--------|---------------|
| #82 | routine/vt-fix-validatejson-undefined-files-260709 | mcp-server/src/server.ts (`validate_json_structure`, files-iteration branch) |
| #81 | routine/vt-fix-autogroup-bookmarks-260708 | src/core/AutoGrouper.ts (bookmark-move on auto-group) |
| #80 | routine/vt-fix-jumptobookmark-clamp-260707 | src/commands.ts (`jumpToBookmark` position clamp, ~L1188-1200) |
| #79 | routine/vt-fix-filemanager-relpath-260706 | src/core/FileManager.ts (`addFilesToGroup`/`removeFilesFromGroup`) |
| #78 | routine/vt-fix-bookmark-stale-groupidx-260703 | src/provider.ts (`getChildren` bookmark-render branch, ~L1852-1860) |
| #77 | routine/vt-fix-treeview-listener-disposal-260702 | src/extension.ts (event-listener subscriptions + revealTimeout disposal, ~L130-260) |
| #76 | release/0.7.6-260701 | release PR, not a code-overlap concern |

This PR does not overlap any of the above:
- `src/provider.ts`: adds a new method `flushPendingSave()` right after the existing `saveGroups()` debounce helper (~L332), nowhere near the bookmark-render branch #78 touches (~L1852).
- `src/extension.ts`: adds one `context.subscriptions.push(...)` at line ~120, immediately after `treeView.description = ...`, which is *before* the listener-registration block #77 modifies (starts ~L137). No line overlap with #77's diff hunks.
- No other open PR touches these two files at all.

## Changes

`TempFoldersProvider` debounces disk writes: every group/file/bookmark edit schedules a `saveGroupsImmediate()` call 500ms later via `setTimeout`, coalescing rapid edits into one write. However, nothing ever flushed that pending timer on extension deactivation. If a user made an edit and closed VS Code within that 500ms window, the timer was simply discarded by the JS runtime and the change was silently lost — never written to `.vscode/virtualTab.json`.

Fix:
- `src/provider.ts`: new public `flushPendingSave()` method — clears the pending debounce timer (if any) and calls the existing synchronous `saveGroupsImmediate()` directly.
- `src/extension.ts`: registers `context.subscriptions.push({ dispose: () => provider.flushPendingSave() })` right after the tree view is created, so VS Code invokes it automatically on deactivation.

This does **not** modify any command registrations, contributed configuration keys, dependencies, or the tab-group serialization/storage format — it only ensures an already-scheduled write actually happens before shutdown.

## Safety Verification

Commands run locally, from the repo root:

- `npx tsc -p ./` → passed, no errors.
- `npm run test` (runs `tsc -p ./ && jest --runInBand`) → **25 test suites, 175 tests, all passed.**

No new test was added: the existing unit-test suite has no `vscode`-module mock/harness for instantiating `TempFoldersProvider` (all current tests exercise pure `src/core/*` logic), so a proper test for this deactivation-hook fix would require scaffolding beyond the scope of a "smallest practical fix" routine PR. This mirrors the precedent set by #77/#78, which also shipped one-line defensive fixes to `extension.ts`/`provider.ts` without new tests.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)