### PR TITLE
[Routine - VT] fix(dragAndDrop): use normalized bookmark key lookup when moving files between groups

### DIFF
--- a/src/core/BookmarkManager.ts
+++ b/src/core/BookmarkManager.ts
@@ -97,7 +97,11 @@ export class BookmarkManager {
     return [...group.bookmarks[bookmarkKey]].sort((a, b) => a.line - b.line);
   }
 
-  private static findBookmarkKey(group: TempGroup, fileUri: string): string | undefined {
+  /**
+   * Find the actual key used in group.bookmarks for a given file URI, tolerating
+   * URI encoding / casing differences (e.g. drag-and-drop payloads vs. stored keys).
+   */
+  static findBookmarkKey(group: TempGroup, fileUri: string): string | undefined {
     if (!group.bookmarks) return undefined;
     if (group.bookmarks[fileUri]) return fileUri;
 

--- a/src/dragAndDrop.ts
+++ b/src/dragAndDrop.ts
@@ -3,6 +3,7 @@ import { TempFoldersProvider } from './provider';
 import { TempFolderItem, TempFileItem, ScopeHeaderItem, EditorGroupItem } from './treeItems';
 import { I18n } from './i18n';
 import { extractDataTransferFileUris, formatDraggedFilesPlainText, parseUriList, uniqueUriStrings } from './core/DropUriParser';
+import { BookmarkManager } from './core/BookmarkManager';
 
 // Drag-and-drop controller, allows files to be dragged into groups AND groups to be nested
 export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropController<vscode.TreeItem> {
@@ -271,14 +272,19 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
             }
 
             // 1. Move Bookmarks
-            if (sourceGroup.bookmarks && sourceGroup.bookmarks[fileUri]) {
+            // Use a normalized key lookup (not exact string match) because the dragged
+            // item's URI string can differ from the stored bookmark key in encoding/casing.
+            const bookmarkKey = sourceGroup.bookmarks
+                ? BookmarkManager.findBookmarkKey(sourceGroup, fileUri)
+                : undefined;
+            if (sourceGroup.bookmarks && bookmarkKey) {
                 if (!targetGroup.bookmarks) {
                     targetGroup.bookmarks = {};
                 }
                 // Move bookmarks to target group
-                targetGroup.bookmarks[fileUri] = sourceGroup.bookmarks[fileUri];
+                targetGroup.bookmarks[bookmarkKey] = sourceGroup.bookmarks[bookmarkKey];
                 // Remove from source group
-                delete sourceGroup.bookmarks[fileUri];
+                delete sourceGroup.bookmarks[bookmarkKey];
 
                 // Clean up empty bookmarks object if needed
                 if (Object.keys(sourceGroup.bookmarks).length === 0) {

--- a/src/test/unit/bookmarkManager.test.ts
+++ b/src/test/unit/bookmarkManager.test.ts
@@ -59,6 +59,32 @@ describe('BookmarkManager URI matching', () => {
         expect(removed).toBe(true);
         expect(group.bookmarks).toEqual({});
     });
+
+    test('findBookmarkKey locates the stored key across groups for drag-and-drop bookmark moves', () => {
+        // Mirrors dragAndDrop.ts#handleFileDrop, where the dragged TreeItem's URI
+        // string can differ in encoding from the key originally saved to disk.
+        const sourceGroup: TempGroup = {
+            id: 'source',
+            name: 'Source',
+            files: [],
+            bookmarks: {
+                '/workspace/project/src/bookmarked.ts': [
+                    { id: 'bm-1', line: 3, label: 'Bookmark', created: 1 }
+                ]
+            }
+        };
+        const targetGroup: TempGroup = { id: 'target', name: 'Target', files: [] };
+        const draggedFileUri = 'file:///workspace/project/src/bookmarked.ts';
+
+        const bookmarkKey = BookmarkManager.findBookmarkKey(sourceGroup, draggedFileUri);
+        expect(bookmarkKey).toBe('/workspace/project/src/bookmarked.ts');
+
+        targetGroup.bookmarks = { [bookmarkKey!]: sourceGroup.bookmarks![bookmarkKey!] };
+        delete sourceGroup.bookmarks![bookmarkKey!];
+
+        expect(targetGroup.bookmarks[bookmarkKey!]).toHaveLength(1);
+        expect(sourceGroup.bookmarks).toEqual({});
+    });
 });
 
 describe('BookmarkManager.createBookmark file membership', () => {


### PR DESCRIPTION
## Pre-flight Check

Open PRs / active routine branches checked (via `gh pr list` and `git branch -r`):

| PR | Files touched |
|---|---|
| #83 flush pending debounced save | `src/extension.ts`, `src/provider.ts` |
| #82 validate_json_structure guard | `mcp-server/src/server.ts` |
| #81 AutoGrouper bookmarks on auto-grouping | `src/core/AutoGrouper.ts`, test |
| #80 jumpToBookmark clamp | `src/commands.ts` |
| #79 FileManager normalized membership | `src/core/FileManager.ts`, test |
| #78 stale groupIdx guard | `src/provider.ts` |
| #77 dispose treeView listeners | `src/extension.ts` |

This PR touches `src/dragAndDrop.ts`, `src/core/BookmarkManager.ts`, and a new/extended test file (`src/test/unit/bookmarkManager.test.ts`). None of these files are touched by any open PR, so there is no overlap.

## Changes

`TempFoldersDragAndDropController.handleFileDrop` (in `src/dragAndDrop.ts`) moves a file's bookmarks to the target group by looking up `sourceGroup.bookmarks[fileUri]` with an **exact string match** on the dragged tree item's URI. The file-move logic immediately below it already accounts for URI encoding/casing differences by comparing `fsPath` instead of raw strings (with a comment explicitly calling this out) — but the bookmark-move branch was never updated to match, so a dragged file whose stored bookmark key doesn't byte-for-byte equal the dragged URI would silently leave its bookmarks behind in the source group instead of moving them.

This mirrors the same class of bug fixed previously in `BookmarkManager.createBookmark` (#73) and `FileManager` (#79, currently open).

Fix:
- `src/core/BookmarkManager.ts`: exported the existing private `findBookmarkKey` static helper (no behavior change — it already normalizes file URI/path differences for bookmark lookups used elsewhere in this class).
- `src/dragAndDrop.ts`: `handleFileDrop` now resolves the bookmark key via `BookmarkManager.findBookmarkKey` before moving/deleting, instead of an exact-match index.
- `src/test/unit/bookmarkManager.test.ts`: added a test exercising the drag-and-drop move scenario (bookmark key resolved from a `file://`-prefixed URI against a stored bare-path key, then moved between two in-memory groups).

Confirms this PR does **not**:
- add/rename/remove any VS Code command registrations
- add/rename/remove any contributed configuration keys in `package.json`
- add, remove, or update any dependencies
- change the tab-group serialization/storage format (bookmarks remain a `Record<string, VTBookmark[]>`; only the *key resolution* during a move is corrected)
- touch `package.json`/`package-lock.json` version fields or `CHANGELOG.md`

## Safety Verification

Ran locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 25 test suites, 176 tests, all passed

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine-maintenance instructions.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If the release-readiness/version-bump gate fails on this PR, that is expected behavior for a routine PR, not a code validation failure.