### PR TITLE
[Routine - VT] fix(i18n): avoid $-pattern corruption in getMessage placeholder substitution

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -64,12 +64,15 @@ export class I18n {
      */
     public static getMessage(key: string, ...args: string[]): string {
         let message = this.messages[key] || key;
-        
-        // Format string (replace {0}, {1}, ... placeholders)
+
+        // Format string (replace {0}, {1}, ... placeholders).
+        // Use a replacer function (not a string) so literal '$' characters in
+        // args (e.g. UNC paths like \\server\C$\path, or error messages)
+        // aren't interpreted as special replacement patterns ($&, $1, ...).
         for (let i = 0; i < args.length; i++) {
-            message = message.replace(new RegExp(`\\{${i}\\}`, 'g'), args[i]);
+            message = message.replace(new RegExp(`\\{${i}\\}`, 'g'), () => args[i]);
         }
-        
+
         return message;
     }
 

--- a/src/test/unit/i18nGetMessage.test.ts
+++ b/src/test/unit/i18nGetMessage.test.ts
@@ -1,0 +1,25 @@
+jest.mock('vscode', () => ({}), { virtual: true });
+
+import { I18n } from '../../i18n';
+
+describe('I18n.getMessage placeholder formatting', () => {
+    test('substitutes a plain placeholder argument', () => {
+        expect(I18n.getMessage('Hello {0}!', 'world')).toBe('Hello world!');
+    });
+
+    test('does not treat a literal $ in an argument as a special replacement pattern', () => {
+        // e.g. a UNC path like \\server\C$\path, which String.replace would
+        // otherwise mangle when the replacement is passed as a raw string.
+        const uncPath = '\\\\server\\C$\\path';
+        expect(I18n.getMessage('Copied to {0}', uncPath)).toBe(`Copied to ${uncPath}`);
+    });
+
+    test('does not expand $& / $$ / $1 style patterns found in an argument', () => {
+        expect(I18n.getMessage('Error: {0}', 'price is $100 (was $$50, ref $&)'))
+            .toBe('Error: price is $100 (was $$50, ref $&)');
+    });
+
+    test('substitutes multiple placeholders independently', () => {
+        expect(I18n.getMessage('{0} -> {1}', 'a$1', 'b')).toBe('a$1 -> b');
+    });
+});


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (Phase 1):
- #85 dragAndDrop/bookmark key lookup — touches `src/core/BookmarkManager.ts`, `src/dragAndDrop.ts`
- #83 flush pending debounced save — touches `src/extension.ts`, `src/provider.ts`
- #82 mcp validate_json_structure guard — touches `mcp-server/src/server.ts`
- #81 AutoGrouper sub-group bookmarks — touches `src/core/AutoGrouper.ts`
- #80 jumpToBookmark clamp — touches `src/commands.ts`
- #79 FileManager relpath — touches `src/core/FileManager.ts`
- #78 provider stale groupIdx guard — touches `src/provider.ts`
- #77 extension.ts listener disposal — touches `src/extension.ts`

This PR only touches `src/i18n.ts` and adds a new test file `src/test/unit/i18nGetMessage.test.ts`. Neither file overlaps with any file touched by the PRs above, and no active `routine/*` remote branch targets `src/i18n.ts`.

## Changes

`I18n.getMessage()` formats `{0}`, `{1}`, ... placeholders using `String.prototype.replace(regex, args[i])`. When the second argument to `replace()` is a **string**, JavaScript interprets `$`-sequences in it specially (`$&`, `$$`, `$1`, `` $` ``, `$'`). Any placeholder argument containing a literal `$` — e.g. a UNC path like `\server\C$\path`, or an error message forwarded via `String(error)` (used throughout `src/sendTo.ts`) — could silently produce corrupted notification text instead of throwing, making the bug easy to miss.

Fix: pass a replacer **function** (`() => args[i]`) instead of a string, so the argument is substituted verbatim with no special-pattern interpretation.

Added `src/test/unit/i18nGetMessage.test.ts` (4 cases) covering: plain substitution, a literal `$` in a UNC-style path, `$&`/`$$`/`$1`-style sequences in an argument, and independent substitution of multiple placeholders.

This PR does not modify any VS Code command registrations, any contributed configuration keys in `package.json`, any dependencies, or the tab-group serialization/storage format.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 26 suites / 179 tests passed (including the 4 new ones)

No `lint` or `format:check` script exists in this repo's `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If GitHub Actions fails only because of the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.