### PR TITLE
[Routine - VT] fix(sendTo): drop malformed send-target entries when loading config

### DIFF
--- a/src/sendTo.ts
+++ b/src/sendTo.ts
@@ -29,8 +29,11 @@ export class SendToManager {
         if (fs.existsSync(newConfigPath)) {
             try {
                 const config = JSON.parse(fs.readFileSync(newConfigPath, 'utf8'));
-                if (Array.isArray(config.sendTargets) && config.sendTargets.length > 0) {
-                    return config.sendTargets;
+                const targets = Array.isArray(config.sendTargets)
+                    ? config.sendTargets.filter(this.isValidSendTarget)
+                    : [];
+                if (targets.length > 0) {
+                    return targets;
                 }
             } catch (error) {
                 console.error('Failed to load sendTargets.json:', error);
@@ -42,8 +45,9 @@ export class SendToManager {
         if (fs.existsSync(legacyConfigPath)) {
             try {
                 const config = JSON.parse(fs.readFileSync(legacyConfigPath, 'utf8'));
-                const targets = config.sendTargets || config.transmitTargets;
-                if (Array.isArray(targets) && targets.length > 0) {
+                const rawTargets = config.sendTargets || config.transmitTargets;
+                const targets = Array.isArray(rawTargets) ? rawTargets.filter(this.isValidSendTarget) : [];
+                if (targets.length > 0) {
                     return targets;
                 }
             } catch (error) {
@@ -57,8 +61,9 @@ export class SendToManager {
             try {
                 const config = JSON.parse(fs.readFileSync(vtPath, 'utf8'));
                 if (!Array.isArray(config)) {
-                    const targets = config.sendTargets || config.transmitTargets;
-                    if (Array.isArray(targets) && targets.length > 0) {
+                    const rawTargets = config.sendTargets || config.transmitTargets;
+                    const targets = Array.isArray(rawTargets) ? rawTargets.filter(this.isValidSendTarget) : [];
+                    if (targets.length > 0) {
                         return targets;
                     }
                 }
@@ -68,6 +73,28 @@ export class SendToManager {
         }
 
         return [];
+    }
+
+    /**
+     * Guards against hand-edited config files where a target is missing its
+     * `name`/`path`, since a malformed entry (e.g. `path: undefined`) would
+     * otherwise reach `path.join()` in sendFile and throw a TypeError.
+     */
+    private static isValidSendTarget(target: unknown): target is SendTarget {
+        if (!target || typeof target !== 'object') {
+            return false;
+        }
+        const candidate = target as Partial<SendTarget>;
+        if (typeof candidate.name !== 'string' || candidate.name.trim().length === 0) {
+            return false;
+        }
+        if (typeof candidate.path === 'string') {
+            return candidate.path.trim().length > 0;
+        }
+        if (Array.isArray(candidate.path)) {
+            return candidate.path.length > 0 && candidate.path.every(p => typeof p === 'string' && p.trim().length > 0);
+        }
+        return false;
     }
 
     private static getWorkspaceRootPath(): string | undefined {

--- a/src/test/unit/sendToLoadTargets.test.ts
+++ b/src/test/unit/sendToLoadTargets.test.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.mock('vscode', () => ({
+    workspace: {
+        workspaceFolders: [] as Array<{ uri: { fsPath: string } }>
+    }
+}), { virtual: true });
+
+import * as vscode from 'vscode';
+import { SendToManager } from '../../sendTo';
+
+function setWorkspaceRoot(root: string): void {
+    (vscode.workspace as unknown as { workspaceFolders: Array<{ uri: { fsPath: string } } >}).workspaceFolders = [
+        { uri: { fsPath: root } }
+    ];
+}
+
+describe('SendToManager.loadSendTargets', () => {
+    let workspaceRoot: string;
+
+    beforeEach(() => {
+        workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vt-sendto-'));
+        fs.mkdirSync(path.join(workspaceRoot, '.vscode'), { recursive: true });
+        setWorkspaceRoot(workspaceRoot);
+    });
+
+    afterEach(() => {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    });
+
+    function writeSendTargets(sendTargets: unknown[]): void {
+        const configPath = path.join(workspaceRoot, '.vscode', 'sendTargets.json');
+        fs.writeFileSync(configPath, JSON.stringify({ sendTargets }), 'utf8');
+    }
+
+    test('drops entries missing a path so callers never receive an undefined destination', () => {
+        writeSendTargets([
+            { name: 'Valid Target' }, // missing path
+            { name: 'Good Target', path: 'D:/deploy' }
+        ]);
+
+        const targets = SendToManager.loadSendTargets();
+
+        expect(targets).toEqual([{ name: 'Good Target', path: 'D:/deploy' }]);
+    });
+
+    test('drops entries missing a name', () => {
+        writeSendTargets([
+            { path: 'D:/deploy' }, // missing name
+            { name: 'Good Target', path: 'D:/deploy' }
+        ]);
+
+        const targets = SendToManager.loadSendTargets();
+
+        expect(targets).toEqual([{ name: 'Good Target', path: 'D:/deploy' }]);
+    });
+
+    test('drops entries whose path array is empty or contains non-string values', () => {
+        writeSendTargets([
+            { name: 'Empty Array', path: [] },
+            { name: 'Bad Array', path: ['D:/ok', null] },
+            { name: 'Good Target', path: ['D:/one', 'D:/two'] }
+        ]);
+
+        const targets = SendToManager.loadSendTargets();
+
+        expect(targets).toEqual([{ name: 'Good Target', path: ['D:/one', 'D:/two'] }]);
+    });
+
+    test('returns an empty array when every entry is malformed', () => {
+        writeSendTargets([{ name: '' }, { path: 'D:/deploy' }, null, 'not-an-object']);
+
+        const targets = SendToManager.loadSendTargets();
+
+        expect(targets).toEqual([]);
+    });
+
+    test('keeps valid entries untouched', () => {
+        writeSendTargets([
+            { name: 'Single', path: 'D:/single' },
+            { name: 'Multi', path: ['D:/a', 'D:/b'] }
+        ]);
+
+        const targets = SendToManager.loadSendTargets();
+
+        expect(targets).toEqual([
+            { name: 'Single', path: 'D:/single' },
+            { name: 'Multi', path: ['D:/a', 'D:/b'] }
+        ]);
+    });
+});


### PR DESCRIPTION
## Pre-flight Check

Open PRs and active branches checked before starting (9 open draft PRs, all `[Routine - VT]`):

| PR | Branch | Files touched |
|----|--------|---------------|
| #86 | routine/vt-fix-i18n-dollar-placeholder-260714 | `src/i18n.ts`, `src/test/unit/i18nGetMessage.test.ts` |
| #85 | routine/vt-fix-dragdrop-bookmark-key-260713 | `src/core/BookmarkManager.ts`, `src/dragAndDrop.ts`, `src/test/unit/bookmarkManager.test.ts` |
| #83 | routine/vt-fix-flush-pending-save-260710 | `src/extension.ts`, `src/provider.ts` |
| #82 | routine/vt-fix-validatejson-undefined-files-260709 | `mcp-server/src/server.ts` |
| #81 | routine/vt-fix-autogroup-bookmarks-260708 | `src/core/AutoGrouper.ts`, `src/test/unit/autoGrouperBookmarks.test.ts` |
| #80 | routine/vt-fix-jumptobookmark-clamp-260707 | `src/commands.ts` |
| #79 | routine/vt-fix-filemanager-relpath-260706 | `src/core/FileManager.ts`, `src/test/unit/fileManagerRelpath.test.ts` |
| #78 | routine/vt-fix-bookmark-stale-groupidx-260703 | `src/provider.ts` |
| #77 | routine/vt-fix-treeview-listener-disposal-260702 | `src/extension.ts` |

This PR only touches `src/sendTo.ts` and adds a new test file `src/test/unit/sendToLoadTargets.test.ts`, neither of which overlaps with any file above.

## Changes

`SendToManager.loadSendTargets()` parses `sendTargets.json` / `transmitConfig.json` / `virtualTab.json` — all hand-editable JSON files — with no runtime shape validation. A target entry missing `path` (or with `path: []`, or a `path` array containing non-string values) previously passed straight through to `pickDestination()` and then to `path.join(destFolder, fileName)` in `sendFile()`, where `destFolder` would be `undefined`/invalid and throw a `TypeError`, crashing the "Send to..." flow.

Added a private `isValidSendTarget()` guard and applied it via `.filter()` at all three config-loading call sites, so malformed entries are silently dropped instead of reaching the file-copy path. Well-formed entries are unaffected.

This PR does **not** modify any VS Code command registrations, contributed configuration keys (`package.json`), dependencies, or the tab-group serialization/storage format. It only tightens validation of an already-existing, already-optional config shape (`SendTarget` in `src/types.ts`, unchanged).

## Safety Verification

Commands run locally, from the repo root:

- `npx tsc -p ./` → passed, no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) → **26 test suites, 180 tests, all passed** (including 5 new tests in `sendToLoadTargets.test.ts` covering: missing path, missing name, empty/invalid path arrays, all-malformed, and valid-entries-untouched)

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)