### PR TITLE
[Routine - VT] fix(GroupManager): treat non-array JSON config as corrupted

### DIFF
--- a/src/core/GroupManager.ts
+++ b/src/core/GroupManager.ts
@@ -68,7 +68,17 @@ export class GroupManager {
 
       // Read and parse the config file
       const content = fs.readFileSync(this.configPath, 'utf8');
-      const groups = JSON.parse(content) as TempGroup[];
+      const parsed: unknown = JSON.parse(content);
+
+      // Config must be an array; anything else (object, string, number, null)
+      // is treated the same as unparsable JSON to avoid corrupting callers
+      // that assume an array (e.g. .find/.filter).
+      if (!Array.isArray(parsed)) {
+        this.handleCorruptedConfig();
+        return { groups: [], version: this.lastModified };
+      }
+
+      const groups = parsed as TempGroup[];
 
       // Update cache
       this.cachedGroups = groups;

--- a/src/test/unit/groupManagerNonArrayConfig.test.ts
+++ b/src/test/unit/groupManagerNonArrayConfig.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit test: GroupManager.loadGroups() handling of non-array JSON content.
+ *
+ * A config file containing valid JSON that is not an array (e.g. an object,
+ * caused by disk corruption or a manual edit) must be treated the same way
+ * as unparsable JSON: back it up and fall back to an empty default config,
+ * rather than returning a non-array value that breaks callers relying on
+ * array methods like .find/.filter.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GroupManager } from '../../core/GroupManager';
+
+function makeTempWorkspace(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vt-test-'));
+    fs.mkdirSync(path.join(dir, '.vscode'));
+    return dir;
+}
+
+function writeRawConfig(dir: string, raw: string): void {
+    fs.writeFileSync(path.join(dir, '.vscode', 'virtualTab.json'), raw, 'utf8');
+}
+
+describe('GroupManager — non-array config content', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = makeTempWorkspace();
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('an object at the JSON root falls back to an empty array and backs up the file', () => {
+        writeRawConfig(tmpDir, JSON.stringify({ id: 'g1', name: 'Not an array' }));
+
+        const manager = new GroupManager(tmpDir);
+        const { groups } = manager.loadGroups();
+
+        expect(groups).toEqual([]);
+
+        const backups = fs
+            .readdirSync(path.join(tmpDir, '.vscode'))
+            .filter(f => f.includes('virtualTab.json.backup.'));
+        expect(backups).toHaveLength(1);
+    });
+
+    test('a bare scalar at the JSON root falls back to an empty array', () => {
+        writeRawConfig(tmpDir, '42');
+
+        const manager = new GroupManager(tmpDir);
+        const { groups } = manager.loadGroups();
+
+        expect(groups).toEqual([]);
+    });
+
+    test('null at the JSON root falls back to an empty array', () => {
+        writeRawConfig(tmpDir, 'null');
+
+        const manager = new GroupManager(tmpDir);
+        const { groups } = manager.loadGroups();
+
+        expect(groups).toEqual([]);
+    });
+});


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs checked (all `[Routine - VT]` daily drafts, `mergeStateStatus: CLEAN`):

| PR | Title | Touched files |
|---|---|---|
| #87 | fix(sendTo): drop malformed send-target entries | `src/sendTo.ts`, test |
| #86 | fix(i18n): avoid $-pattern corruption | `src/i18n.ts`, test |
| #85 | fix(dragAndDrop): normalized bookmark key lookup | `src/core/BookmarkManager.ts`, `src/dragAndDrop.ts`, test |
| #83 | fix(provider): flush pending debounced save on deactivation | `src/extension.ts`, `src/provider.ts` |
| #82 | fix(mcp): guard files iteration in validate_json_structure | `mcp-server/src/server.ts` |
| #81 | fix(AutoGrouper): move bookmarks to sub-groups | `src/core/AutoGrouper.ts`, test |
| #80 | fix(commands): clamp bookmark position | `src/commands.ts` |
| #79 | fix(FileManager): normalized membership check | `src/core/FileManager.ts`, test |
| #78 | fix(provider): guard stale groupIdx | `src/provider.ts` |
| #77 | fix(extension): dispose treeView listeners | `src/extension.ts` |

This PR only touches `src/core/GroupManager.ts` and adds a new test file
(`src/test/unit/groupManagerNonArrayConfig.test.ts`). Neither file overlaps
with any file listed above, so there is no conflict with in-flight routine
work.

## 2. Changes

`GroupManager.loadGroups()` parsed the on-disk config JSON and cast it
directly to `TempGroup[]` without checking the parsed value was actually an
array. A config file containing syntactically valid JSON that isn't an
array (e.g. an object or scalar from a partial/manual write) would silently
propagate a non-array value to callers that assume array methods
(`.find`, `.filter`, etc.), instead of going through the existing
corrupted-config recovery path (backup the bad file + reset to `[]`).

The fix adds an `Array.isArray` check right after `JSON.parse` and routes
non-array content through the same `handleCorruptedConfig()` path already
used for JSON parse failures.

Confirms this PR does **not**:
- add/remove/rename any VS Code command registrations
- add/remove/rename any `package.json` contributed configuration keys
- modify any dependencies or `package.json`/`package-lock.json`
- change the tab-group serialization format (still a `TempGroup[]` JSON array on disk)
- change configuration storage/migration logic in a way that could corrupt existing user data (a well-formed array config is completely unaffected)

## 3. Safety Verification

Commands run locally, in order:

```
npx tsc -p ./
```
Result: passed, no output/errors.

```
npm run test
```
Result: `tsc -p ./ && jest --runInBand` — **26 test suites passed, 178 tests passed**, 0 failures.

(No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.)

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json` /
`package-lock.json`) and `CHANGELOG.md` consolidation are intentionally
deferred to the weekend release/integration PR. If the repository's
version-bump CI gate fails on this PR for that reason, that is expected
release-readiness behavior, not a code validation failure.