### PR TITLE
[Routine - VT] fix(mcp-server): poll for workspace root instead of checking once at 3s

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -124,15 +124,23 @@ async function main() {
     // 4. Create the VirtualTabs MCP Server
     const server = new VirtualTabsMCPServer(validatedWorkspaceRoot);
 
-    // 5. Persist workspace root when the Roots protocol sets it.
-    // Polling after 3 s gives the Roots handshake time to complete.
-    setTimeout(() => {
+    // 5. Persist workspace root once the Roots protocol handshake completes.
+    // Handshake timing varies by client, so poll periodically for up to 30 s
+    // instead of checking only once after a fixed delay, which could miss
+    // slower clients and silently skip caching for that session.
+    let pollAttempts = 0;
+    const MAX_POLL_ATTEMPTS = 30;
+    const pollHandle = setInterval(() => {
+      pollAttempts += 1;
       const root = server.getWorkspaceRoot();
       if (root) {
         saveState({ lastWorkspaceRoot: root });
         console.error(`[INFO] Workspace path cached: ${root}`);
+        clearInterval(pollHandle);
+      } else if (pollAttempts >= MAX_POLL_ATTEMPTS) {
+        clearInterval(pollHandle);
       }
-    }, 3000);
+    }, 1000);
 
     // 6. Create the stdio transport and connect
     const transport = new StdioServerTransport();


### PR DESCRIPTION
## 1. Pre-flight Check

Checked open PRs and active routine branches before selecting a target:

- Open PRs: #88 (GroupManager), #87 (sendTo), #86 (i18n), #85 (BookmarkManager/dragAndDrop), #83 (extension/provider), #82 (mcp-server/server.ts), #81 (AutoGrouper), #80 (commands.ts), #79 (FileManager), #78 (provider.ts), #77 (extension.ts).
- Touched files across those PRs: `src/core/GroupManager.ts`, `src/sendTo.ts`, `src/i18n.ts`, `src/core/BookmarkManager.ts`, `src/dragAndDrop.ts`, `src/extension.ts`, `src/provider.ts`, `mcp-server/src/server.ts`, `src/core/AutoGrouper.ts`, `src/commands.ts`, `src/core/FileManager.ts`.
- This PR touches only `mcp-server/src/index.ts`, which is not modified by any open PR or active routine branch — no overlap.

(Note: `gh pr diff` returned transient `503`s from the GitHub API during this run, so file lists were cross-checked via `git diff --name-only origin/main...origin/<branch>` against the corresponding remote branches instead.)

## 2. Changes

`mcp-server/src/index.ts` — the one-shot `setTimeout(..., 3000)` that persists the Roots-protocol workspace root to `~/.virtualtabs-mcp-state.json` is replaced with a `setInterval` that polls once per second for up to 30 attempts, clearing itself as soon as the root is found (or once the attempt budget is exhausted). The Roots handshake completes at a client-dependent pace; a single check at a fixed 3s delay could miss slower clients and silently skip the cache for that session, forcing a fresh Roots round-trip on every subsequent launch.

This PR does **not** modify any VS Code command registrations, contributed configuration keys (`package.json`), dependencies, or the tab-group serialization/storage format. It touches only server-bootstrap polling logic in a single file.

## 3. Safety Verification

Commands run locally, both passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 25 suites / 175 tests passed

No lint or format:check script exists in this project's `package.json`, so neither was run.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.