### PR TITLE
[Routine - VT] fix(treeItems): use folder.name for ScopeHeaderItem label instead of path.basename

### DIFF
--- a/src/core/ConfigScopeDiscovery.ts
+++ b/src/core/ConfigScopeDiscovery.ts
@@ -8,7 +8,6 @@
  */
 
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { ConfigScope, TempGroup } from '../types.js';
 
 export class ConfigScopeDiscovery {
@@ -57,14 +56,14 @@ export class ConfigScopeDiscovery {
 
     /**
      * 從 WorkspaceFolder 建立 folder scope。
-     * label 為資料夾名稱（path.basename）。
+     * label 使用 VS Code 已計算好的 folder.name（尊重多根工作區自訂名稱，
+     * 並在資料夾為磁碟根目錄等 path.basename 會回傳空字串的邊緣情況下保有正確名稱）。
      */
     private static createFolderScope(folder: vscode.WorkspaceFolder): ConfigScope {
-        const folderName = path.basename(folder.uri.fsPath);
         return {
             id: folder.uri.toString(),
             type: 'folder',
-            label: folderName,
+            label: folder.name,
             uri: folder.uri,
             groups: [] as TempGroup[]
         };

--- a/src/test/unit/ConfigScopeDiscovery.test.ts
+++ b/src/test/unit/ConfigScopeDiscovery.test.ts
@@ -5,6 +5,7 @@
  * - 單一資料夾工作區
  * - 多根工作區（含 workspaceFile）
  * - 無工作區資料夾
+ * - folder scope label 使用 folder.name（而非重新以 path.basename 推導）
  */
 
 import * as path from 'path';
@@ -57,11 +58,10 @@ function discoverScopes(
 
     if (workspaceFolders && workspaceFolders.length > 0) {
         for (const folder of workspaceFolders) {
-            const folderName = path.basename(folder.uri.fsPath);
             scopes.push({
                 id: folder.uri.toString(),
                 type: 'folder',
-                label: folderName,
+                label: folder.name,
                 uri: folder.uri,
                 groups: []
             });
@@ -104,6 +104,22 @@ describe('ConfigScopeDiscovery 單元測試', () => {
             const scopes = discoverScopes(undefined, folders);
 
             expect(scopes[0].id).toBe(folderUri.toString());
+        });
+
+        test('資料夾為磁碟根目錄時，label 仍應使用 folder.name（path.basename 在此情況會回傳空字串）', () => {
+            // 例如在 Windows 開啟 "C:\" 或在 POSIX 開啟 "/" 作為工作區資料夾，
+            // path.basename(fsPath) 會是 ''，但 VS Code 已在 folder.name 提供正確名稱。
+            const folders = [{ uri: createMockUri('/'), name: 'root' }];
+            const scopes = discoverScopes(undefined, folders);
+
+            expect(scopes[0].label).toBe('root');
+        });
+
+        test('多根工作區自訂資料夾名稱時，label 應使用 folder.name 而非 basename', () => {
+            const folders = [{ uri: createMockUri('/home/user/Repo-A'), name: 'Custom Display Name' }];
+            const scopes = discoverScopes(undefined, folders);
+
+            expect(scopes[0].label).toBe('Custom Display Name');
         });
     });
 

--- a/src/test/unit/ScopeHeaderItem.test.ts
+++ b/src/test/unit/ScopeHeaderItem.test.ts
@@ -3,12 +3,10 @@
  *
  * 測試 label 生成邏輯和 contextValue 設定：
  * - workspace scope 的 label 應為 'Workspace Config'
- * - folder scope 的 label 應為 'Project: [folderName]'
+ * - folder scope 的 label 應為 'Project: [scope.label]'
  * - 多 scope 時 contextValue 應為 'virtualTabsScopeHeaderWithAdd'
  * - 非互動式（command 應為 undefined）
  */
-
-import * as path from 'path';
 
 // ─── 模擬 ScopeHeaderItem 邏輯（不依賴 vscode API）──────────────────────────
 
@@ -33,12 +31,14 @@ interface MockScopeHeaderItem {
 }
 
 function createScopeHeaderItem(
-    scope: { id: string; type: 'workspace' | 'folder'; uri: MockUri },
+    scope: { id: string; type: 'workspace' | 'folder'; label: string; uri: MockUri },
     hasMultipleScopes: boolean
 ): MockScopeHeaderItem {
+    // ScopeHeaderItem 使用 scope.label（由 ConfigScopeDiscovery 以 folder.name 計算），
+    // 而非重新以 path.basename(scope.uri.fsPath) 推導，避免磁碟根目錄等 basename 為空字串的邊緣情況。
     const label = scope.type === 'workspace'
         ? 'Workspace Config'
-        : `Project: ${path.basename(scope.uri.fsPath)}`;
+        : `Project: ${scope.label}`;
 
     return {
         label,
@@ -56,6 +56,7 @@ describe('ScopeHeaderItem 單元測試', () => {
             const scope = {
                 id: 'file:///workspace',
                 type: 'workspace' as const,
+                label: 'Workspace',
                 uri: createMockUri('/workspace')
             };
             const item = createScopeHeaderItem(scope, true);
@@ -66,6 +67,7 @@ describe('ScopeHeaderItem 單元測試', () => {
             const scope = {
                 id: 'file:///workspace',
                 type: 'workspace' as const,
+                label: 'Workspace',
                 uri: createMockUri('/workspace')
             };
             const item = createScopeHeaderItem(scope, true);
@@ -76,6 +78,7 @@ describe('ScopeHeaderItem 單元測試', () => {
             const scope = {
                 id: 'file:///workspace',
                 type: 'workspace' as const,
+                label: 'Workspace',
                 uri: createMockUri('/workspace')
             };
             const item = createScopeHeaderItem(scope, false);
@@ -84,30 +87,57 @@ describe('ScopeHeaderItem 單元測試', () => {
     });
 
     describe('folder scope', () => {
-        test('label 應為 "Project: [folderName]"', () => {
+        test('label 應為 "Project: [scope.label]"', () => {
             const scope = {
                 id: 'file:///workspace/Repo-A',
                 type: 'folder' as const,
+                label: 'Repo-A',
                 uri: createMockUri('/workspace/Repo-A')
             };
             const item = createScopeHeaderItem(scope, true);
             expect(item.label).toBe('Project: Repo-A');
         });
 
-        test('label 應使用 path.basename 取得資料夾名稱', () => {
+        test('label 應直接使用 scope.label', () => {
             const scope = {
                 id: 'file:///home/user/my-awesome-project',
                 type: 'folder' as const,
+                label: 'my-awesome-project',
                 uri: createMockUri('/home/user/my-awesome-project')
             };
             const item = createScopeHeaderItem(scope, true);
             expect(item.label).toBe('Project: my-awesome-project');
         });
 
+        test('資料夾為磁碟根目錄（scope.label 由 folder.name 提供）時，label 不應為空白', () => {
+            // path.basename('/') 會回傳 ''，若重新以 uri.fsPath 推導會顯示 "Project: "。
+            // scope.label 應直接沿用 ConfigScopeDiscovery 已計算好的 folder.name。
+            const scope = {
+                id: 'file:///',
+                type: 'folder' as const,
+                label: 'root',
+                uri: createMockUri('/')
+            };
+            const item = createScopeHeaderItem(scope, true);
+            expect(item.label).toBe('Project: root');
+        });
+
+        test('多根工作區自訂資料夾名稱時，label 應使用 scope.label 而非 uri 推導出的 basename', () => {
+            const scope = {
+                id: 'file:///home/user/Repo-A',
+                type: 'folder' as const,
+                label: 'Custom Display Name',
+                uri: createMockUri('/home/user/Repo-A')
+            };
+            const item = createScopeHeaderItem(scope, true);
+            expect(item.label).toBe('Project: Custom Display Name');
+        });
+
         test('多 scope 時 contextValue 應為 "virtualTabsScopeHeaderWithAdd"', () => {
             const scope = {
                 id: 'file:///workspace/Repo-A',
                 type: 'folder' as const,
+                label: 'Repo-A',
                 uri: createMockUri('/workspace/Repo-A')
             };
             const item = createScopeHeaderItem(scope, true);
@@ -120,6 +150,7 @@ describe('ScopeHeaderItem 單元測試', () => {
             const scope = {
                 id: 'file:///workspace',
                 type: 'workspace' as const,
+                label: 'Workspace',
                 uri: createMockUri('/workspace')
             };
             const item = createScopeHeaderItem(scope, true);
@@ -130,6 +161,7 @@ describe('ScopeHeaderItem 單元測試', () => {
             const scope = {
                 id: 'file:///workspace',
                 type: 'workspace' as const,
+                label: 'Workspace',
                 uri: createMockUri('/workspace')
             };
             const item = createScopeHeaderItem(scope, true);

--- a/src/treeItems.ts
+++ b/src/treeItems.ts
@@ -96,9 +96,12 @@ export class ScopeHeaderItem extends vscode.TreeItem {
         hasMultipleScopes: boolean = true,
         expanded: boolean = true
     ) {
+        // Use scope.label (set by ConfigScopeDiscovery from VS Code's own
+        // WorkspaceFolder.name) instead of re-deriving via path.basename,
+        // which returns '' when a folder is opened at a filesystem root.
         const label = scope.type === 'workspace'
             ? 'Workspace Config'
-            : `Project: ${path.basename(scope.uri.fsPath)}`;
+            : `Project: ${scope.label}`;
 
         super(label, expanded
             ? vscode.TreeItemCollapsibleState.Expanded


### PR DESCRIPTION
## Pre-flight Check

Checked open PRs and active branches before selecting this target (2026-07-22):

- #91 `dependabot/npm_and_yarn/npm_and_yarn-0cbacde004` — touches `mcp-server/package-lock.json`, `package-lock.json`
- #89 `routine/vt-fix-mcp-workspace-poll-260717` — touches `mcp-server/src/index.ts`
- #88 `routine/vt-fix-groupmanager-nonarray-json-260716` — touches `src/core/GroupManager.ts`
- #87 `routine/vt-fix-sendto-malformed-target-260715` — touches `src/sendTo.ts`
- #86 `routine/vt-fix-i18n-dollar-placeholder-260714` — touches `src/i18n.ts`
- #85 `routine/vt-fix-dragdrop-bookmark-key-260713` — touches `src/core/BookmarkManager.ts`, `src/dragAndDrop.ts`
- #83 `routine/vt-fix-flush-pending-save-260710` — touches `src/extension.ts`, `src/provider.ts`
- #82 `routine/vt-fix-validatejson-undefined-files-260709` — touches `mcp-server/src/server.ts`
- #81 `routine/vt-fix-autogroup-bookmarks-260708` — touches `src/core/AutoGrouper.ts`
- #80 `routine/vt-fix-jumptobookmark-clamp-260707` — touches `src/commands.ts`
- #79 `routine/vt-fix-filemanager-relpath-260706` — touches `src/core/FileManager.ts`
- #78 `routine/vt-fix-bookmark-stale-groupidx-260703` — touches `src/provider.ts`
- #77 `routine/vt-fix-treeview-listener-disposal-260702` — touches `src/extension.ts`

This PR touches `src/core/ConfigScopeDiscovery.ts`, `src/treeItems.ts`, and their two unit test files — none of which appear in any open PR's changed-file list, so there is no overlap.

## Changes

`ScopeHeaderItem` (in `src/treeItems.ts`) built its "Project: …" tree-view label by re-deriving the folder name from `scope.uri.fsPath` via `path.basename(...)`. `path.basename` returns an empty string when a workspace folder is opened at a filesystem root (e.g. `C:\` on Windows, or `/` on POSIX), which produced a blank `"Project: "` label — a minor UI glitch.

VS Code already computes a robust, edge-case-safe folder display name on `vscode.WorkspaceFolder.name` (it also respects custom names configured per-folder in multi-root `.code-workspace` files). `ConfigScopeDiscovery.createFolderScope` now stores `folder.name` directly into `scope.label`, and `ScopeHeaderItem` reads `scope.label` instead of re-deriving it from the URI, removing the duplicate/fragile logic and fixing the root-path edge case.

Also updated the two existing unit tests (`ConfigScopeDiscovery.test.ts`, `ScopeHeaderItem.test.ts`) to mirror the fixed logic and added edge-case coverage for filesystem-root folders and custom multi-root folder names.

Confirms this PR does **not**:
- rename/add/delete any VS Code command registrations
- rename/add/delete any contributed configuration keys
- modify dependencies or `package.json`/`package-lock.json`
- touch the tab-group serialization format or config storage/migration logic

## Safety Verification

Ran locally from repo root:

```
npx tsc -p ./
```
→ passed, no errors.

```
npm run test
```
(runs `tsc -p ./ && jest --runInBand`)
→ **25 test suites passed, 179 tests passed**, 0 failed.

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine-maintainer instructions.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.