### PR TITLE
[Routine - VT] fix(extension): dispose FileSystemWatcher when a scope's workspace folder is removed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,14 +9,14 @@ import { ConfigScope } from './types';
 
 /**
  * 為每個 ConfigScope 建立 FileSystemWatcher，監看 .vscode/virtualTab.json。
- * 回傳所有建立的 watcher，以便後續 dispose。
+ * 回傳 scopeId → watcher 的對應表，以便後續依 scope 個別 dispose。
  */
 function setupWatchers(
     scopes: ConfigScope[],
     provider: TempFoldersProvider,
     context: vscode.ExtensionContext
-): vscode.FileSystemWatcher[] {
-    const watchers: vscode.FileSystemWatcher[] = [];
+): Map<string, vscode.FileSystemWatcher> {
+    const watchers = new Map<string, vscode.FileSystemWatcher>();
 
     for (const scope of scopes) {
         const pattern = new vscode.RelativePattern(
@@ -36,7 +36,7 @@ function setupWatchers(
         });
 
         context.subscriptions.push(watcher);
-        watchers.push(watcher);
+        watchers.set(scopeId, watcher);
     }
 
     return watchers;
@@ -253,19 +253,28 @@ export async function activate(context: vscode.ExtensionContext) {
     registerCommands(context, provider, () => lastSelectedCustomFile, stableMcpPath, treeView);
 
     // 為每個 ConfigScope 建立 FileSystemWatcher（多 scope 支援）
-    setupWatchers(provider.configScopes, provider, context);
-    const watchedScopeIds = new Set<string>(provider.configScopes.map(s => s.id));
+    const scopeWatchers = setupWatchers(provider.configScopes, provider, context);
 
     // 監聽工作區資料夾動態變更（新增/移除 folder）
     context.subscriptions.push(
         vscode.workspace.onDidChangeWorkspaceFolders(() => {
             // 重新執行 discovery 並更新 provider 的 configScopes
             provider.reinitializeScopes();
+            const currentScopeIds = new Set(provider.configScopes.map(s => s.id));
+
+            // 移除 folder 後其 scope 已不存在，dispose 對應的 watcher 避免資源洩漏
+            for (const [scopeId, watcher] of scopeWatchers) {
+                if (!currentScopeIds.has(scopeId)) {
+                    watcher.dispose();
+                    scopeWatchers.delete(scopeId);
+                }
+            }
+
             // 為新增的 scope 建立 FileSystemWatcher（避免重複建立已有的）
-            const newScopes = provider.configScopes.filter(s => !watchedScopeIds.has(s.id));
+            const newScopes = provider.configScopes.filter(s => !scopeWatchers.has(s.id));
             if (newScopes.length > 0) {
-                setupWatchers(newScopes, provider, context);
-                newScopes.forEach(s => watchedScopeIds.add(s.id));
+                const newWatchers = setupWatchers(newScopes, provider, context);
+                newWatchers.forEach((watcher, scopeId) => scopeWatchers.set(scopeId, watcher));
             }
         })
     );


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (Phase 1):
- #94 `fix/publish-package-prerelease-flag` — touches `.github/workflows/publish.yml` only.
- #92 `routine/vt-fix-scopeheader-foldername-260722` (Draft) — touches `src/core/ConfigScopeDiscovery.ts`, `src/treeItems.ts`, and related tests (`ScopeHeaderItem`/`ConfigScopeDiscovery` unit tests).
- #91 `dependabot/npm_and_yarn/npm_and_yarn-0cbacde004` — touches `package-lock.json` / `mcp-server/package-lock.json` only.

This PR only touches `src/extension.ts` (the `setupWatchers` helper and the `onDidChangeWorkspaceFolders` handler), which none of the above PRs modify. No overlap.

## Changes

`setupWatchers()` previously returned a plain array of `FileSystemWatcher`s. In the `onDidChangeWorkspaceFolders` handler, only scopes *added* after a workspace-folder change got new watchers registered (tracked via a `watchedScopeIds` `Set`) — but when a folder was *removed*, `reinitializeScopes()` drops the corresponding `ConfigScope` while its `FileSystemWatcher` kept running and was never disposed. Repeatedly adding/removing the same folder within a session would accumulate stale watchers for the life of the extension host.

`setupWatchers()` now returns a `Map<scopeId, FileSystemWatcher>`. The change-handler diffs the current scope ids against the tracked map on every workspace-folder change and calls `.dispose()` on watchers whose scope no longer exists, removing them from the map, before registering watchers for any newly discovered scopes.

Confirms this PR does **not**:
- add/rename/remove any VS Code command registration
- add/rename/remove any contributed configuration key in `package.json`
- add, remove, or update any dependency
- touch tab-group serialization or config storage/migration logic

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 30 test suites / 194 tests passed

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)