### PR TITLE
fix(AutoGrouper): move bookmarks and preserve built-in visibility in the real UI command path

### DIFF
--- a/src/core/AutoGrouper.ts
+++ b/src/core/AutoGrouper.ts
@@ -98,7 +98,7 @@ export class AutoGrouper {
    * Without this, bookmarks are orphaned on the (now empty) source group
    * and become unreachable from the UI.
    */
-  private static moveBookmarks(sourceGroup: TempGroup, targetGroup: TempGroup, fileUris: string[]): void {
+  static moveBookmarks(sourceGroup: TempGroup, targetGroup: TempGroup, fileUris: string[]): void {
     if (!sourceGroup.bookmarks) return;
 
     for (const fileUri of fileUris) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1409,14 +1409,18 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         });
 
         // Insert auto groups at the original group position (after it)
-        const newGroups = Object.entries(extMap).map(([ext, files]) => ({
-            id: Date.now().toString() + Math.random().toString(36).substring(2, 9),
-            name: `${I18n.getAutoGroupName(ext)} @ ${group.name}`, // Naming: .ext @ Source
-            files,
-            auto: true,
-            sourceGroupId: group.id,
-            sourceScopeId: group.sourceScopeId
-        }));
+        const newGroups: TempGroup[] = Object.entries(extMap).map(([ext, files]) => {
+            const newGroup: TempGroup = {
+                id: Date.now().toString() + Math.random().toString(36).substring(2, 9),
+                name: `${I18n.getAutoGroupName(ext)} @ ${group.name}`, // Naming: .ext @ Source
+                files,
+                auto: true,
+                sourceGroupId: group.id,
+                sourceScopeId: group.sourceScopeId
+            };
+            AutoGrouper.moveBookmarks(group, newGroup, files);
+            return newGroup;
+        });
 
         // Find fresh index of group because filtering might have shifted it
         const newGroupIdx = this.groups.findIndex(g => g.id === group.id);
@@ -1477,7 +1481,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         for (const dateGroup of dateOrder) {
             const files = dateGroups.get(dateGroup);
             if (files && files.length > 0) {
-                newGroups.push({
+                const newGroup: TempGroup = {
                     id: Date.now().toString() + Math.random().toString(36).substring(2, 9),
                     name: `${I18n.getMessage('group.autoGroupPrefix')} ${AutoGrouper.getDateGroupLabel(dateGroup, I18n)} @ ${group.name}`, // Naming: [Auto] Label @ Source
                     files,
@@ -1485,7 +1489,9 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                     autoGroupType: 'modifiedDate',
                     sourceGroupId: group.id,
                     sourceScopeId: group.sourceScopeId
-                });
+                };
+                AutoGrouper.moveBookmarks(group, newGroup, files);
+                newGroups.push(newGroup);
             }
         }
 
@@ -1660,6 +1666,14 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                 return item;
             };
 
+            // Auto sub-groups created from the built-in group ("Currently Open Files")
+            // never get `builtIn: true` themselves, only `sourceGroupId` pointing back
+            // to it. Scope-filtered views must still surface them alongside the
+            // built-in group, otherwise Auto Group by Extension/Date on it appears
+            // to silently do nothing when a scope filter is active.
+            const isBuiltInFamily = (group: TempGroup): boolean =>
+                !!group.builtIn || this.groups.find(g => g.id === group.sourceGroupId)?.builtIn === true;
+
             const isFiltered = this.activeScopeIds.size > 0;
 
             if (isFiltered) {
@@ -1669,7 +1683,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                 const builtInItems = showBuiltIn
                     ? this.groups
                         .map((g, idx) => ({ group: g, idx }))
-                        .filter(({ group }) => group.builtIn)
+                        .filter(({ group }) => isBuiltInFamily(group))
                         .map(({ group, idx }) => makeFolderItem(group, idx))
                     : [];
 
@@ -1719,7 +1733,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                 );
                 const builtInItems = this.groups
                     .map((g, idx) => ({ group: g, idx }))
-                    .filter(({ group }) => group.builtIn)
+                    .filter(({ group }) => isBuiltInFamily(group))
                     .map(({ group, idx }) => makeFolderItem(group, idx));
                 return [...builtInItems, ...scopeItems];
             }

--- a/src/test/unit/autoGroupProviderRegression.test.ts
+++ b/src/test/unit/autoGroupProviderRegression.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Regression test for the real provider.ts Auto Group commands.
+ *
+ * autoGrouperBookmarks.test.ts and autoGroupScopeId.test.ts only exercise
+ * core/AutoGrouper.ts (the MCP-tool layer) or a hand-mirrored copy of the
+ * creation logic — neither calls TempFoldersProvider.addAutoGroupsByExt()
+ * or .autoGroupByModifiedDate() themselves, which is what the tree view's
+ * "Auto Group by Extension/Date" commands actually invoke. That gap let a
+ * real regression ship in v0.7.7: bookmarks were dropped on auto-group, and
+ * auto sub-groups created from the built-in "Currently Open Files" group
+ * were invisible whenever a scope filter was active.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import type { TempGroup, ConfigScope } from '../../types';
+
+jest.mock('vscode', () => {
+    class Uri {
+        private constructor(public readonly fsPath: string) { }
+
+        static file(fsPath: string): Uri {
+            return new Uri(path.resolve(fsPath));
+        }
+
+        static parse(value: string): Uri {
+            if (value.startsWith('file://')) {
+                return new Uri(new URL(value).pathname);
+            }
+            return new Uri(value);
+        }
+
+        static joinPath(base: Uri, ...segments: string[]): Uri {
+            return new Uri(path.join(base.fsPath, ...segments));
+        }
+
+        toString(): string {
+            return pathToFileURL(this.fsPath).toString();
+        }
+    }
+
+    class TreeItem {
+        id?: string;
+        resourceUri?: Uri;
+        command?: unknown;
+        iconPath?: unknown;
+        tooltip?: unknown;
+        contextValue?: string;
+        collapsibleState?: number;
+
+        constructor(public readonly label: unknown, collapsibleState?: number) {
+            this.collapsibleState = collapsibleState;
+        }
+    }
+
+    return {
+        Uri,
+        TreeItem,
+        TreeItemCollapsibleState: {
+            None: 0,
+            Collapsed: 1,
+            Expanded: 2
+        },
+        EventEmitter: class {
+            event = jest.fn();
+            fire = jest.fn();
+        },
+        ThemeIcon: Object.assign(
+            class {
+                constructor(public readonly id: string, public readonly color?: unknown) { }
+            },
+            { File: { id: 'file' } }
+        ),
+        ThemeColor: class {
+            constructor(public readonly id: string) { }
+        },
+        TabInputText: class { },
+        TabInputNotebook: class { },
+        TabInputCustom: class { },
+        TabInputTextDiff: class { },
+        commands: {
+            executeCommand: jest.fn()
+        },
+        window: {
+            tabGroups: { all: [] },
+            showErrorMessage: jest.fn(),
+            showInformationMessage: jest.fn()
+        },
+        workspace: {
+            workspaceFolders: []
+        }
+    };
+}, { virtual: true });
+
+import { TempFoldersProvider, BUILTIN_SCOPE_ID } from '../../provider';
+import { TempFolderItem } from '../../treeItems';
+
+function makeTempWorkspace(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vt-provider-autogroup-test-'));
+    return dir;
+}
+
+function createProviderHarness(groups: TempGroup[], configScopes: ConfigScope[]): TempFoldersProvider {
+    const provider = Object.create(TempFoldersProvider.prototype) as TempFoldersProvider;
+    provider.groups = groups;
+    provider.configScopes = configScopes;
+    (provider as unknown as { activeScopeIds: Set<string> }).activeScopeIds = new Set();
+    (provider as unknown as { expandedGroupIds: Set<string> }).expandedGroupIds = new Set();
+    jest.spyOn(provider, 'refresh').mockImplementation(jest.fn());
+    return provider;
+}
+
+function selectGroup(provider: TempFoldersProvider, groupIdx: number, group: TempGroup): void {
+    const item = new TempFolderItem(group.name, groupIdx, group.id, group.builtIn);
+    (provider as unknown as { treeView: { selection: unknown[] } }).treeView = {
+        selection: [item]
+    };
+}
+
+describe('TempFoldersProvider auto-group commands (real provider.ts code path)', () => {
+    let workspaceDir: string;
+
+    beforeEach(() => {
+        workspaceDir = makeTempWorkspace();
+    });
+
+    afterEach(() => {
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+    });
+
+    test('addAutoGroupsByExt moves bookmarks to the new extension sub-groups', () => {
+        const tsFile = pathToFileURL(path.join(workspaceDir, 'a.ts')).toString();
+        const mdFile = pathToFileURL(path.join(workspaceDir, 'b.md')).toString();
+
+        const group: TempGroup = {
+            id: 'group-1',
+            name: 'Source',
+            files: [tsFile, mdFile],
+            bookmarks: {
+                [tsFile]: [{ id: 'bm-1', line: 5, label: 'ts bookmark', created: 1 }],
+                [mdFile]: [{ id: 'bm-2', line: 1, label: 'md bookmark', created: 2 }]
+            }
+        };
+
+        const provider = createProviderHarness([group], []);
+        selectGroup(provider, 0, group);
+
+        provider.addAutoGroupsByExt();
+
+        // Bookmarks must not be left orphaned on the source group.
+        expect(group.bookmarks).toBeUndefined();
+
+        const tsGroup = provider.groups.find(g => g.files?.includes(tsFile) && g.id !== group.id);
+        const mdGroup = provider.groups.find(g => g.files?.includes(mdFile) && g.id !== group.id);
+
+        expect(tsGroup?.bookmarks?.[tsFile]).toEqual([{ id: 'bm-1', line: 5, label: 'ts bookmark', created: 1 }]);
+        expect(mdGroup?.bookmarks?.[mdFile]).toEqual([{ id: 'bm-2', line: 1, label: 'md bookmark', created: 2 }]);
+    });
+
+    test('autoGroupByModifiedDate moves bookmarks to the new date sub-groups', () => {
+        const filePath = path.join(workspaceDir, 'today.ts');
+        fs.writeFileSync(filePath, 'export {};');
+        const fileUri = pathToFileURL(filePath).toString();
+
+        const group: TempGroup = {
+            id: 'group-1',
+            name: 'Source',
+            files: [fileUri],
+            bookmarks: {
+                [fileUri]: [{ id: 'bm-1', line: 3, label: 'date bookmark', created: 1 }]
+            }
+        };
+
+        const provider = createProviderHarness([group], []);
+        selectGroup(provider, 0, group);
+
+        provider.autoGroupByModifiedDate();
+
+        expect(group.bookmarks).toBeUndefined();
+
+        const dateGroup = provider.groups.find(g => g.files?.includes(fileUri) && g.id !== group.id);
+        expect(dateGroup?.bookmarks?.[fileUri]).toEqual([{ id: 'bm-1', line: 3, label: 'date bookmark', created: 1 }]);
+    });
+
+    test('auto sub-groups created from the built-in group stay visible when a scope filter is active', () => {
+        const tsFile = pathToFileURL(path.join(workspaceDir, 'a.ts')).toString();
+
+        const builtInGroup: TempGroup = {
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [tsFile],
+            builtIn: true
+        };
+
+        // A real (non-built-in) scope must exist for the "isFiltered" branch
+        // in getChildren() to be exercised the same way a multi-root
+        // workspace would.
+        const scope: ConfigScope = {
+            id: 'scope:project',
+            type: 'folder',
+            label: 'project',
+            uri: { fsPath: workspaceDir } as never,
+            groups: []
+        };
+
+        const provider = createProviderHarness([builtInGroup], [scope]);
+        selectGroup(provider, 0, builtInGroup);
+
+        provider.addAutoGroupsByExt();
+
+        // Only the built-in scope is active in the sidebar filter.
+        (provider as unknown as { activeScopeIds: Set<string> }).activeScopeIds = new Set([BUILTIN_SCOPE_ID]);
+
+        const children = provider.getChildren() as TempFolderItem[];
+        const labels = children.map(c => c.label);
+
+        expect(labels).toContain('Currently Open Files');
+        expect(children.length).toBeGreaterThan(1);
+    });
+});


### PR DESCRIPTION
## Summary
- PR #81 fixed bookmark loss on Auto Group by Extension/Date, but only in `core/AutoGrouper.ts` (the MCP-tool layer). The actual tree view commands (`provider.ts` `addAutoGroupsByExt`/`autoGroupByModifiedDate`) are a separate implementation PR #81 never touched — bookmarks were still dropped when using the real UI. Confirmed live while manually testing the v0.7.7 pre-release.
- Second bug found in the same test pass: auto sub-groups created from the built-in "Currently Open Files" group don't carry `builtIn: true`, so `getChildren()`'s scope-filtered branches (which only surface `group.builtIn` items) silently excluded them whenever a scope filter was active — Auto Group on the built-in group appeared to do nothing.
- `AutoGrouper.moveBookmarks` is now `public static` and reused from `provider.ts`, instead of leaving a third parallel copy of the same logic.
- Adds `autoGroupProviderRegression.test.ts`, which calls the real `provider.ts` methods directly. Existing `autoGrouperBookmarks.test.ts` and `autoGroupScopeId.test.ts` only test `core/AutoGrouper.ts` or a hand-mirrored copy of the creation logic — that gap is exactly how this shipped undetected.

## Test plan
- [x] `npx tsc -p ./` clean
- [x] `npm test` — all pre-existing tests still pass (2 unrelated failures from `.claude/worktrees/` duplicate test files picked up by jest, pre-existing, not touched by this PR)
- [x] New regression tests fail against the pre-fix code (verified by stashing the fix and re-running) and pass with it applied
- [ ] Manual smoke test in the next pre-release build: Auto Group by Extension/Date on a bookmarked group, and on "Currently Open Files" with a scope filter active