### PR TITLE
[Routine - VT] fix(provider): avoid duplicate built-in group on scoped resetToDefault

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -453,8 +453,8 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
      */
     public resetToDefault(scopeId?: string) {
         if (scopeId) {
-            // 只移除屬於該 scope 的群組
-            this.groups = this.groups.filter(g => g.builtIn || g.sourceScopeId !== scopeId);
+            // 只移除屬於該 scope 的群組；內建群組一併移除，交由 initBuiltInGroup() 重建單一份
+            this.groups = this.groups.filter(g => !g.builtIn && g.sourceScopeId !== scopeId);
         } else {
             this.groups = [];
         }

--- a/src/test/unit/autoGroupProviderRegression.test.ts
+++ b/src/test/unit/autoGroupProviderRegression.test.ts
@@ -219,4 +219,31 @@ describe('TempFoldersProvider auto-group commands (real provider.ts code path)',
         expect(labels).toContain('Currently Open Files');
         expect(children.length).toBeGreaterThan(1);
     });
+
+    test('resetToDefault(scopeId) does not leave a duplicate built-in group', () => {
+        // Reproduces the FileSystemWatcher onDidDelete path in extension.ts,
+        // which calls provider.resetToDefault(scopeId) when a scope's
+        // virtualTab.json is deleted on disk.
+        const builtInGroup: TempGroup = {
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [],
+            builtIn: true
+        };
+
+        const scopedGroup: TempGroup = {
+            id: 'group-1',
+            name: 'Scoped',
+            files: [],
+            sourceScopeId: 'scope:project'
+        };
+
+        const provider = createProviderHarness([builtInGroup, scopedGroup], []);
+
+        provider.resetToDefault('scope:project');
+
+        const builtInGroups = provider.groups.filter(g => g.builtIn);
+        expect(builtInGroups).toHaveLength(1);
+        expect(provider.groups.find(g => g.id === 'group-1')).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## 1. Pre-flight Check

- No open PRs at time of this run (`gh pr list --state open` returned `[]`).
- Checked all `routine/vt-fix-*` remote branches present in `git branch -r`; cross-referenced with `gh pr list --state all` and confirmed every one of them is already **MERGED** into `main` (most recently #95 `watcher-stale-scope`, #92 `scopeheader-foldername`, #89 `mcp-workspace-poll`, #88 `groupmanager-nonarray-json`, #87 `sendto-malformed-target`, #86 `i18n-dollar-placeholder`, #85 `dragdrop-bookmark-key`, #83 `flush-pending-save`). None of these touch `src/provider.ts`'s `resetToDefault()`/`initBuiltInGroup()` logic.
- This PR does not overlap with any active branch or open PR.

## 2. Changes

`TempFoldersProvider.resetToDefault(scopeId)` (`src/provider.ts`) is called from `extension.ts`'s `watcher.onDidDelete` handler whenever a scope's `.vscode/virtualTab.json` is deleted on disk. When called with a `scopeId`, its filter kept the *existing* built-in group (`g.builtIn` short-circuit) and then unconditionally called `initBuiltInGroup()`, which `unshift`s a *new* built-in group object with the same fixed id (`'builtin_group_id'`). The result: two built-in group entries in `this.groups`, producing a duplicated "Currently Open Files" node in the tree view. The non-scoped branch (`this.groups = []`) and the sibling `loadGroups()` method already avoid this by clearing/reusing built-in groups before calling `initBuiltInGroup()`.

Fix: exclude built-in groups from the retained set in the scoped branch too, since `initBuiltInGroup()` always recreates exactly one:

```ts
this.groups = this.groups.filter(g => !g.builtIn && g.sourceScopeId !== scopeId);
```

Added a regression test (`src/test/unit/autoGroupProviderRegression.test.ts`) asserting `resetToDefault(scopeId)` leaves exactly one built-in group.

Confirms this PR does **not** modify commands, contributed configuration keys, dependencies, or the tab-group serialization/storage format.

## 3. Safety Verification

Local commands run, both passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 31 test suites, 202 tests, all passed

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG updates are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.