### PR TITLE
fix(provider): don't persist auto sub-groups sourced from the built-in group

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -158,6 +158,17 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         return this.expandedGroupIds.has(id);
     }
 
+    /**
+     * True for the built-in group itself, or for an auto sub-group whose
+     * sourceGroupId traces back to it. Auto sub-groups never get
+     * `builtIn: true` themselves (only `sourceGroupId`), so both the
+     * scope-filtered tree rendering and the save-routing logic need this
+     * to treat them consistently as "not a real persisted, scoped group".
+     */
+    isBuiltInFamily(group: TempGroup): boolean {
+        return !!group.builtIn || this.groups.find(g => g.id === group.sourceGroupId)?.builtIn === true;
+    }
+
     updateScopeExpanded(id: string, expanded: boolean): string[] {
         if (expanded) {
             this.expandedScopeIds.add(id);
@@ -359,7 +370,11 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
             );
 
             for (const group of this.groups) {
-                if (group.builtIn) continue; // 內建群組不持久化
+                // 內建群組（及其自動子群組）不持久化：子群組沒有 sourceScopeId，
+                // 若不在此排除，會落入下方「無 sourceScopeId」的向下相容分支，
+                // 被誤存到第一個 scope 的檔案裡，導致下次載入後在該 scope 底下
+                // 重複顯示一次（除了原本就會顯示在頂層的內建群組區塊之外）。
+                if (this.isBuiltInFamily(group)) continue;
 
                 const scopeId = group.sourceScopeId;
                 if (!scopeId) {
@@ -1666,14 +1681,6 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                 return item;
             };
 
-            // Auto sub-groups created from the built-in group ("Currently Open Files")
-            // never get `builtIn: true` themselves, only `sourceGroupId` pointing back
-            // to it. Scope-filtered views must still surface them alongside the
-            // built-in group, otherwise Auto Group by Extension/Date on it appears
-            // to silently do nothing when a scope filter is active.
-            const isBuiltInFamily = (group: TempGroup): boolean =>
-                !!group.builtIn || this.groups.find(g => g.id === group.sourceGroupId)?.builtIn === true;
-
             const isFiltered = this.activeScopeIds.size > 0;
 
             if (isFiltered) {
@@ -1683,7 +1690,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                 const builtInItems = showBuiltIn
                     ? this.groups
                         .map((g, idx) => ({ group: g, idx }))
-                        .filter(({ group }) => isBuiltInFamily(group))
+                        .filter(({ group }) => this.isBuiltInFamily(group))
                         .map(({ group, idx }) => makeFolderItem(group, idx))
                     : [];
 
@@ -1733,7 +1740,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                 );
                 const builtInItems = this.groups
                     .map((g, idx) => ({ group: g, idx }))
-                    .filter(({ group }) => isBuiltInFamily(group))
+                    .filter(({ group }) => this.isBuiltInFamily(group))
                     .map(({ group, idx }) => makeFolderItem(group, idx));
                 return [...builtInItems, ...scopeItems];
             }

--- a/src/test/unit/autoGroupProviderRegression.test.ts
+++ b/src/test/unit/autoGroupProviderRegression.test.ts
@@ -219,4 +219,53 @@ describe('TempFoldersProvider auto-group commands (real provider.ts code path)',
         expect(labels).toContain('Currently Open Files');
         expect(children.length).toBeGreaterThan(1);
     });
+
+    // Regression: auto sub-groups sourced from the built-in group have no
+    // sourceScopeId (same as the built-in group itself), so the save-routing
+    // "no sourceScopeId -> fall back to first scope" compatibility branch was
+    // silently persisting them into whichever real scope's storage file
+    // happened to be first. On reload they came back with a real
+    // sourceScopeId, so they rendered a second time under that scope's
+    // ScopeHeaderItem in addition to the top-level built-in section —
+    // reported live as duplicated "[自動] .ts @ 目前已開啟檔案" folders.
+    test('auto sub-groups created from the built-in group are never persisted to a real scope', () => {
+        const tsFile = pathToFileURL(path.join(workspaceDir, 'a.ts')).toString();
+
+        const builtInGroup: TempGroup = {
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [tsFile],
+            builtIn: true
+        };
+
+        const scope: ConfigScope = {
+            id: 'scope:project',
+            type: 'folder',
+            label: 'project',
+            uri: { fsPath: workspaceDir } as never,
+            groups: []
+        };
+
+        const provider = Object.create(TempFoldersProvider.prototype) as TempFoldersProvider;
+        provider.groups = [builtInGroup];
+        provider.configScopes = [scope];
+        (provider as unknown as { activeScopeIds: Set<string> }).activeScopeIds = new Set();
+        (provider as unknown as { expandedGroupIds: Set<string> }).expandedGroupIds = new Set();
+        (provider as unknown as { _onDidChangeTreeData: { fire: jest.Mock } })._onDidChangeTreeData = { fire: jest.fn() };
+        (provider as unknown as { builtInEditorGroups: unknown[] }).builtInEditorGroups = [];
+
+        const saveGroups = jest.fn();
+        const loadGroups = jest.fn().mockReturnValue({ groups: [], version: 0 });
+        (provider as unknown as { groupManagers: Map<string, { saveGroups: typeof saveGroups; loadGroups: typeof loadGroups }> }).groupManagers =
+            new Map([['scope:project', { saveGroups, loadGroups }]]);
+        (provider as unknown as { loadedVersions: Map<string, number> }).loadedVersions = new Map([['scope:project', 0]]);
+
+        selectGroup(provider, 0, builtInGroup);
+        provider.addAutoGroupsByExt();
+        provider.flushPendingSave();
+
+        expect(saveGroups).toHaveBeenCalledTimes(1);
+        const persistedGroups = saveGroups.mock.calls[0][0] as TempGroup[];
+        expect(persistedGroups).toEqual([]);
+    });
 });


### PR DESCRIPTION
## Summary
Follow-up to #96, found live while manually testing 0.7.8 in a multi-root workspace.

- Auto sub-groups created from the built-in "Currently Open Files" group have no `sourceScopeId` (inherited from the built-in group, which never has one).
- `saveGroupsImmediate()`'s "no sourceScopeId → fall back to the first available scope" compatibility branch was silently persisting them into whichever real scope's storage file happened to be first.
- On reload they came back with a real `sourceScopeId`, so they rendered a **second time** nested under that scope's `ScopeHeaderItem`, in addition to the top-level built-in section — reported as duplicated `[自動] .ts @ 目前已開啟檔案` folders.
- Promotes the `isBuiltInFamily()` check (previously a closure local to `getChildren()`, added in #96) to a shared `TempFoldersProvider` method, and applies it in the save-routing skip alongside the existing `group.builtIn` check.

## Test plan
- [x] New regression test reproduces the duplicate-persistence bug against pre-fix code (verified via `git stash`), passes with the fix
- [x] `npx tsc -p ./` clean
- [x] Full suite: 766/766 tests pass
- [ ] Manual: multi-root workspace, Auto Group by Extension/Date on "目前已開啟檔案" with an active scope filter, reload window, confirm no duplicate folders appear under any `ScopeHeaderItem`