### PR TITLE
docs(ci): require explicit confirmation before triggering ui-tests.yml

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,5 +1,14 @@
 name: UI Tests (Manual)
 
+# ⚠️ DO NOT trigger this workflow (via `gh workflow run`, the Actions UI, or
+# any other means) without the repo owner's explicit, per-instance
+# confirmation — including from an AI coding agent/tool acting on their
+# behalf. It consumes CI minutes on a full Electron/Selenium suite and has
+# not been validated for reliability in this CI environment (timeouts seen
+# on a first run are not necessarily a code regression — they may just mean
+# the existing wait timeouts are tuned for local dev machines, not shared
+# runners). Always ask first; do not assume prior approval carries over.
+
 on:
   workflow_dispatch:
 permissions:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -553,6 +553,8 @@ AI assistants may default to running shell commands (`npm run test:ui`, `git`, e
 > Suggested instruction when starting a session:
 > *"Output all terminal commands for me to run in VS Code's integrated terminal. Do not execute them yourself."*
 
+**This also applies to the `UI Tests (Manual)` GitHub Actions workflow** (`.github/workflows/ui-tests.yml`) — an AI assistant must never trigger it (`gh workflow run`, clicking "Run workflow" in the Actions UI, etc.) without your explicit, per-instance confirmation, even if it previously ran local shell commands without asking. It burns CI minutes on a full Electron/Selenium suite that has not been validated for reliability on shared runners, and a prior approval for one action does not carry over to this one.
+
 ---
 
 ## ⚙️ Context Key: `virtualTabs:hasMultipleScopes`


### PR DESCRIPTION
## Summary
- DEVELOPMENT.md already told AI assistants not to run E2E tests themselves in a local sandbox, but said nothing about the CI-hosted "UI Tests (Manual)" workflow. An agent triggered it via `gh workflow run` without asking first — it had never been run before and turned out to have widespread pre-existing timeouts on the shared runner.
- Adds an explicit warning comment to `ui-tests.yml` and extends the DEVELOPMENT.md AI notes to also cover `workflow_dispatch` triggers, not just local shell execution.

## Test plan
- Docs/comment-only change, no functional impact.