### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.8.0] - Stable Release: Auto Group Fixes Promoted to Stable - 2026-07-26
+
+### ✅ Stable Promotion
+
+- Promotes the Auto Group bookmark-preservation and built-in scope-visibility fixes (#96, shipped in the 0.7.8 pre-release) to the stable release tier after manual E2E verification.
+
+### 🧪 Testing
+
+- **test(ui):** add E2E coverage for Auto Group bookmark preservation and built-in duplicate persistence (#100)
+
+### 📝 Documentation
+
+- **docs(ci):** require explicit confirmation before triggering `ui-tests.yml` (#101)
+
 ## [0.7.8] - Auto Group Bookmark & Scope-Visibility Fixes - 2026-07-23
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.7.8",
+    "version": "0.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.7.8",
+            "version": "0.8.0",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.7.8",
+    "version": "0.8.0",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [


### PR DESCRIPTION
## Summary
- Bumps version to 0.8.0 (even minor → stable tier per versioning convention)
- Promotes the Auto Group bookmark-preservation and built-in scope-visibility fixes (#96, shipped in 0.7.8 pre-release) to stable after manual E2E verification (#100)
- Adds CI guardrail requiring explicit confirmation before triggering `ui-tests.yml` manually (#101)

## Test plan
- [x] Full unit suite (`npm test`)
- [x] Full E2E suite (`npm run test:ui`) — 189 passing, 1 pending (known scope-filter limitation, tracked separately)