### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.9.0] - Built-in Auto-Group Duplicate Persistence Fixes (pre-release) - 2026-07-26
+
+### 🐛 Bug Fixes
+
+- **fix(provider):** don't persist auto sub-groups sourced from the built-in "Currently Open Files" group — they previously fell back to being saved into whichever real scope's storage file happened to be first, then re-rendered a second time under that scope's header on reload (#99)
+- **fix(provider):** avoid duplicate built-in group on scoped `resetToDefault` — deleting a scope's `virtualTab.json` on disk could leave two built-in group entries in the tree (#98)
+
 ## [0.8.0] - Stable Release: Auto Group Fixes Promoted to Stable - 2026-07-26
 
 ### ✅ Stable Promotion

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.8.0",
+            "version": "0.9.0",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [


### PR DESCRIPTION
## Summary
- Bumps version to 0.9.0 (odd minor → pre-release tier per versioning convention)
- Includes #99 (built-in auto-group duplicate-persistence fix) and #98 (resetToDefault duplicate built-in group fix)

## Test plan
- [x] Full unit suite (`npm test`): 774/774 passing, verified locally after resolving the merge conflict between #99 and #98